### PR TITLE
Adding asynchronous read functionality

### DIFF
--- a/.github/scripts/build_artOS.sh
+++ b/.github/scripts/build_artOS.sh
@@ -1,4 +1,23 @@
 #!/usr/bin/env sh
+
+#
+# ArtOS - hobby operating system by Artie Poole
+# Copyright (C) 2025 Stuart Forbes Poole <artiepoole>
+#
+#     This program is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+#
+#     This program is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
+#
+#     You should have received a copy of the GNU General Public License
+#     along with this program.  If not, see <https://www.gnu.org/licenses/>
+#
+
 set -e
 cmake -S ./ -B cmake-build-artos -DCMAKE_TOOLCHAIN_FILE=./toolchain.cmake -DENABLE_SERIAL_LOGGING:BOOL=ON -DENABLE_TERMINAL_LOGGING:BOOL=OFF
 cmake --build cmake-build-artos -t ArtOS

--- a/.github/scripts/check_output.py
+++ b/.github/scripts/check_output.py
@@ -1,3 +1,21 @@
+#!/usr/bin/env python3
+
+#  ArtOS - hobby operating system by Artie Poole
+#  Copyright (C) 2025 Stuart Forbes Poole <artiepoole>
+#
+#      This program is free software: you can redistribute it and/or modify
+#      it under the terms of the GNU General Public License as published by
+#      the Free Software Foundation, either version 3 of the License, or
+#      (at your option) any later version.
+#
+#      This program is distributed in the hope that it will be useful,
+#      but WITHOUT ANY WARRANTY; without even the implied warranty of
+#      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#      GNU General Public License for more details.
+#
+#      You should have received a copy of the GNU General Public License
+#      along with this program.  If not, see <https://www.gnu.org/licenses/>
+
 from pathlib import Path
 
 # TODO: The main.cpp file should print progress markers with a given string in them and this should look only through each of those in order and match them to expected result.

--- a/.github/scripts/run_qemu_tests.sh
+++ b/.github/scripts/run_qemu_tests.sh
@@ -1,5 +1,23 @@
 #!/usr/bin/env sh
 
+#
+# ArtOS - hobby operating system by Artie Poole
+# Copyright (C) 2025 Stuart Forbes Poole <artiepoole>
+#
+#     This program is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+#
+#     This program is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
+#
+#     You should have received a copy of the GNU General Public License
+#     along with this program.  If not, see <https://www.gnu.org/licenses/>
+#
+
 # https://gist.github.com/mvidner/8939289 - qemu characters
 # TODO: implement the JSON version
 # https://www.qemu.org/docs/master/devel/qapi-code-gen.html

--- a/.github/workflows/ArtOSTypesTest.yaml
+++ b/.github/workflows/ArtOSTypesTest.yaml
@@ -15,4 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: test
-        run: . ./.github/scripts/cmake_test.sh
+        run: |
+          echo "::group::cmake_test.sh"
+          ./.github/scripts/cmake_test.sh
+          echo "::endgroup::"

--- a/.github/workflows/buildandrun.yaml
+++ b/.github/workflows/buildandrun.yaml
@@ -15,19 +15,30 @@ jobs:
         uses: actions/checkout@v4
       - name: install
         run: |
+          echo "::group::install dependencies"
           # TODO: https://github.com/thought-machine/please/tree/master/tools/images#updating-images <- this but maybe lxc
           sudo dpkg --add-architecture i386
           sudo apt update
           sudo apt upgrade
           sudo apt install -y gcc-multilib g++-multilib libc6:i386 libstdc++6:i386 qemu-system-x86 mtools grub-common grub-pc-bin socat xorriso
+          echo "::endgroup::"
       - name: build
-        run: . ./.github/scripts/build_artOS.sh
+        run: |
+          echo "::group::build"
+          ./.github/scripts/build_artOS.sh
+          echo "::endgroup::"
       - name: qemu-test
-        run: . ./.github/scripts/run_qemu_tests.sh
+        run: |
+          echo "::group::test"
+          ./.github/scripts/run_qemu_tests.sh
+          echo "::endgroup::"
       - name: report_output
-        run: cat serial.log
+        run: |
+          echo "::group::serial.log"
+          cat serial.log
+          echo "::endgroup::"
       - name: check_output
-        run: python3 ./.github/scripts/check_output.py
+        run: "echo \"::group::run check_output.py\"\npython3 ./.github/scripts/check_output.py\necho \"::endgroup::\" \n"
 
 # TODO: This should test building with and without terminal logging. I currently have a broken build with terminal.
 # TODO: This should also build with debug mode and release mode with terminal and without

--- a/ArtOSTypes/Lists/LinkedList.h
+++ b/ArtOSTypes/Lists/LinkedList.h
@@ -35,14 +35,24 @@ class LinkedList
     LinkedListNode* _tail = nullptr;
 
 public:
-    T* head()
+    T* head_data()
     {
         return &_head->data;
     }
 
-    T* tail()
+    T* tail_data()
     {
         return &_tail->data;
+    }
+
+    LinkedListNode* head()
+    {
+        return _head;
+    }
+
+    LinkedListNode* tail()
+    {
+        return &_tail;
     }
 
     bool append(T data)

--- a/ArtOSTypes/Lists/LinkedList.h
+++ b/ArtOSTypes/Lists/LinkedList.h
@@ -168,7 +168,6 @@ public:
         }
         return nullptr;
     }
-
 };
 
 //TODO: doubly linked list

--- a/ArtOS_lib/kernel.cpp
+++ b/ArtOS_lib/kernel.cpp
@@ -24,7 +24,8 @@
 
 
 extern "C" {
-int write(int fd, const char *buf, unsigned long count) {
+int write(int fd, const char* buf, unsigned long count)
+{
     int result;
     asm volatile(
         "int $0x80" // Trigger software interrupt
@@ -35,7 +36,8 @@ int write(int fd, const char *buf, unsigned long count) {
     return result;
 }
 
-int read(int fd, char *buf, size_t count) {
+int read(int fd, char* buf, size_t count)
+{
     int result;
     asm volatile(
         "int $0x80" // Trigger software interrupt
@@ -46,7 +48,8 @@ int read(int fd, char *buf, size_t count) {
     return result;
 }
 
-int open(const char *pathname, int flags) {
+int open(const char* pathname, int flags)
+{
     int result;
     asm volatile(
         "int $0x80" // Trigger software interrupt
@@ -57,7 +60,8 @@ int open(const char *pathname, int flags) {
     return result;
 }
 
-void _exit(int status) {
+void _exit(int status)
+{
     asm volatile(
         "int $0x80" // Trigger software interrupt
         :
@@ -67,7 +71,8 @@ void _exit(int status) {
     while (true);
 }
 
-void sleep_ms(u32 ms) {
+void sleep_ms(u32 ms)
+{
     asm volatile(
         "int $0x80" // Trigger software interrupt
         :
@@ -76,7 +81,8 @@ void sleep_ms(u32 ms) {
     );
 }
 
-u32 get_tick_ms() {
+u32 get_tick_ms()
+{
     u32 result;
     asm volatile(
         "int $0x80" // Trigger software interrupt
@@ -87,7 +93,8 @@ u32 get_tick_ms() {
     return result;
 }
 
-bool probe_pending_events() {
+bool probe_pending_events()
+{
     bool result;
     asm volatile(
         "int $0x80" // Trigger software interrupt
@@ -98,7 +105,8 @@ bool probe_pending_events() {
     return result;
 }
 
-event_t get_next_event() {
+event_t get_next_event()
+{
     u32 type, data_low, data_high;
     asm volatile(
         "int $0x80" // Trigger software interrupt
@@ -109,7 +117,8 @@ event_t get_next_event() {
     return event_t{static_cast<EVENT_TYPE>(type), event_data_t{data_low, data_high}};
 }
 
-void draw_screen_region(const u32 *frame_buffer) {
+void draw_screen_region(const u32* frame_buffer)
+{
     asm volatile(
         "int $0x80" // Trigger software interrupt
         :
@@ -118,7 +127,8 @@ void draw_screen_region(const u32 *frame_buffer) {
     );
 }
 
-int get_time(tm *dest) {
+int get_time(tm* dest)
+{
     int result;
     asm volatile(
         "int $0x80" // Trigger software interrupt
@@ -129,7 +139,8 @@ int get_time(tm *dest) {
     return result;
 }
 
-long get_epoch_time() {
+long get_epoch_time()
+{
     long result;
     asm volatile(
         "int $0x80" // Trigger software interrupt
@@ -140,7 +151,8 @@ long get_epoch_time() {
     return result;
 }
 
-u32 get_ebp() {
+u32 get_ebp()
+{
     u32 ebp;
     asm("mov %%ebp,%0" : "=r"(ebp));
     return ebp;
@@ -151,10 +163,11 @@ u32 get_ebp() {
 //     asm volatile("mov %0, %%ebp" :: "r"(ebp));
 // }
 
-void *mmap(void *addr, size_t length, int prot, int flags, int fd, size_t offset) {
+void* mmap(void* addr, size_t length, int prot, int flags, int fd, size_t offset)
+{
     // u32 old_ebp;
 
-    void *result;
+    void* result;
     // asm volatile( "push %0"::"r"(offset):"memory");
     asm volatile(
         "int $0x80" // Trigger software interrupt
@@ -172,7 +185,8 @@ void *mmap(void *addr, size_t length, int prot, int flags, int fd, size_t offset
     return result;
 }
 
-void munmap(void *addr, size_t length) {
+void munmap(void* addr, size_t length)
+{
     asm volatile(
         "int $0x80" // Trigger software interrupt
         :
@@ -183,7 +197,8 @@ void munmap(void *addr, size_t length) {
     );
 }
 
-u64 get_current_clock() {
+u64 get_current_clock()
+{
     int low, high;
     asm volatile(
         "int $0x80" // Trigger software interrupt
@@ -194,7 +209,8 @@ u64 get_current_clock() {
     return low | (static_cast<u64>(high) << 32);
 }
 
-int execf(int fd) {
+int execf(int fd)
+{
     int ret;
     asm volatile(
         "int $0x80" // Trigger software interrupt
@@ -205,7 +221,8 @@ int execf(int fd) {
     return ret;
 }
 
-void yield() {
+void yield()
+{
     asm volatile(
         "int $0x80" // Trigger software interrupt
         :
@@ -215,7 +232,8 @@ void yield() {
 }
 }
 
-int close(const int fd) {
+int close(const int fd)
+{
     int ret;
     asm volatile(
         "int $0x80" // Trigger software interrupt
@@ -226,7 +244,8 @@ int close(const int fd) {
     return ret;
 }
 
-i64 seek(int fd, i64 offset, int whence) {
+i64 seek(int fd, i64 offset, int whence)
+{
     int ret_high, ret_low;
     u32 off_low = offset & 0xFFFFFFFF;
     i32 off_high = offset >> 32;
@@ -240,7 +259,8 @@ i64 seek(int fd, i64 offset, int whence) {
     return ret;
 }
 
-void clear_term() {
+void clear_term()
+{
     asm volatile(
         "int $0x80" // Trigger software interrupt
         :

--- a/ArtOS_lib/kernel.h
+++ b/ArtOS_lib/kernel.h
@@ -31,7 +31,8 @@ extern "C" {
 #endif
 
 
-enum SYSCALL_t {
+enum SYSCALL_t
+{
     WRITE,
     READ,
     SEEK,
@@ -57,13 +58,13 @@ typedef struct tm tm;
 typedef struct event_t event_t;
 
 // files
-int write(int fd, const char *buf, unsigned long count);
+int write(int fd, const char* buf, unsigned long count);
 
-int read(int fd, char *buf, size_t count);
+int read(int fd, char* buf, size_t count);
 
 i64 seek(int fd, i64 offset, int whence);
 
-int open(const char *pathname, int flags);
+int open(const char* pathname, int flags);
 
 int close(const int fd);
 
@@ -74,7 +75,7 @@ void sleep_ms(u32 ms);
 
 u32 get_tick_ms();
 
-int get_time(tm *dest);
+int get_time(tm* dest);
 
 long get_epoch_time();
 
@@ -86,14 +87,14 @@ bool probe_pending_events();
 event_t get_next_event();
 
 // graphics
-void draw_screen_region(const u32 *frame_buffer);
+void draw_screen_region(const u32* frame_buffer);
 
 void clear_term();
 
 // memory
-void *mmap(void *addr, size_t length, int prot, int flags, int fd, size_t offset);
+void* mmap(void* addr, size_t length, int prot, int flags, int fd, size_t offset);
 
-void munmap(void *addr, size_t length);
+void munmap(void* addr, size_t length);
 
 // scheduling
 int execf(int fid);

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,8 @@ add_executable(${KERNEL_BIN}
         ${Generic}
         ${Specific}
         ${ArchitectureSpecific}
+        Generic/sys/Scheduling/io_queue_entry.h
+        Generic/sys/Scheduling/IO_Read.cpp
 )
 
 if(CMAKE_BUILD_TYPE STREQUAL "Release")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,13 +3,13 @@ option(ENABLE_SERIAL_LOGGING "Enables serial logging using LOG, WRITE, NEWLINE m
 option(ENABLE_TERMINAL_LOGGING "Overrides serial logging. Enables terminal logging using LOG, WRITE, NEWLINE macros. Only if logging is enabled." OFF)
 option(SIMD "Replace memcpy with SIMD version?" ON)
 option(FORLAPTOP "Enable building for real hardware, disable for QEMU." OFF)
+option(ASYNC_READ "Enable asynchronous IO. Warning: poor performance." ON)
 
 project(ArtOS)
 ENABLE_LANGUAGE(ASM)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_C_STANDARD 11)
-
 
 set(KERNEL_LIB "ArtOS_lib")
 set(KERNEL_NAME ${CMAKE_PROJECT_NAME})
@@ -55,6 +55,9 @@ add_executable(${KERNEL_BIN}
         ${ArchitectureSpecific}
 )
 
+if(CMAKE_BUILD_TYPE STREQUAL "Release")
+    target_compile_definitions(${KERNEL_BIN} PRIVATE NDEBUG)
+endif()
 
 target_include_directories(
         ${KERNEL_BIN} PUBLIC#if SIMD
@@ -123,8 +126,8 @@ target_compile_definitions(${KERNEL_BIN}
         ENABLE_TERMINAL_LOGGING=$<BOOL:${ENABLE_TERMINAL_LOGGING}>
         SIMD=$<BOOL:${SIMD}>
         FORLAPTOP=$<BOOL:${FORLAPTOP}>
+        ASYNC_READ=$<BOOL:${ASYNC_READ}>
 )
-
 
 target_link_libraries(${KERNEL_BIN} PUBLIC pdclib ArtOSTypes)
 

--- a/Generic/main.cpp
+++ b/Generic/main.cpp
@@ -286,8 +286,6 @@ void kernel_main(unsigned long magic, unsigned long boot_info_addr)
     vga.draw();
 
 
-
-
     LOG("LOADED OS. Entering event loop.");
 
     [[maybe_unused]] auto scheduler = new Scheduler(local_apic, &kernel_events);

--- a/Generic/sys/Communication/Serial.h
+++ b/Generic/sys/Communication/Serial.h
@@ -29,7 +29,8 @@ class ArtFile;
 
 #define PORT 0x3f8          // COM1
 
-class Serial : public StorageDevice {
+class Serial : public StorageDevice
+{
 private:
     static char _read_one_byte();
 
@@ -39,7 +40,7 @@ private:
 
     static int _get_transmit_empty();
 
-    static void _write_buffer(const char *data, size_t size);
+    static void _write_buffer(const char* data, size_t size);
 
     char name[11] = "/dev/com1";
 
@@ -51,12 +52,12 @@ public:
     // ~Serial();
 
     // static Serial& get();
-    ArtFile *&get_file();
+    ArtFile*& get_file();
 
     // remove copy functionality
-    Serial(Serial const &other) = delete;
+    Serial(Serial const& other) = delete;
 
-    Serial &operator=(Serial const &other) = delete;
+    Serial& operator=(Serial const& other) = delete;
 
     bool connected;
 
@@ -69,19 +70,21 @@ public:
     // void write(unsigned char c);
     void write(char c);
 
-    void write(const char *data);
+    void write(const char* data);
 
-    void write(const char *data, size_t len);
+    void write(const char* data, size_t len);
 
-    u32 com_read(char *dest, u32 count);
+    u32 com_read(char* dest, u32 count);
 
-    u32 com_write(const char *data, u32 count);
+    u32 com_write(const char* data, u32 count);
 
-    i64 read(char *dest, [[maybe_unused]] size_t byte_offset, size_t byte_count) override {
+    i64 read(char* dest, [[maybe_unused]] size_t byte_offset, size_t byte_count) override
+    {
         return com_read(dest, byte_count);
     }
 
-    i64 write(const char *data, [[maybe_unused]] size_t byte_offset, size_t byte_count) override {
+    i64 write(const char* data, [[maybe_unused]] size_t byte_offset, size_t byte_count) override
+    {
         return com_write(data, byte_count);
     }
 
@@ -89,12 +92,13 @@ public:
     i64 async_read(char* dest, [[maybe_unused]] size_t byte_offset, size_t byte_count) override { return -1; }
     bool device_busy() override { return false; }
     virtual i64 async_n_read() { return -1; }
-    char *get_name() override { return name; }
+    char* get_name() override { return name; }
 
 
     int mount() { return 0; }
 
-    ArtFile *find_file([[maybe_unused]] const char *filename) override {
+    ArtFile* find_file([[maybe_unused]] const char* filename) override
+    {
         if (art_string::strcmp(filename, "/dev/com1") == 0) return get_file();
         else return nullptr;
     }
@@ -107,38 +111,46 @@ public:
 
     void time_stamp();
 
-    template<typename int_like>
+    template <typename int_like>
         requires is_int_like_v<int_like> && (!is_same_v<int_like, char>)
     // Any interger like number but not a char or char array.
-    void write(const int_like val, const bool hex = false) {
+    void write(const int_like val, const bool hex = false)
+    {
         char out_str[255];
-        if (hex) {
+        if (hex)
+        {
             art_string::hex_from_int(val, out_str, sizeof(val));
-        } else {
+        }
+        else
+        {
             art_string::string_from_int(val, out_str);
         }
         write(out_str);
     }
 
-    template<typename type_t>
-    void log(type_t const &arg1) {
+    template <typename type_t>
+    void log(type_t const& arg1)
+    {
         time_stamp();
         write(arg1);
         newLine();
     }
 
-    template<typename... args_t>
-    void log(args_t &&... args) {
+    template <typename... args_t>
+    void log(args_t&&... args)
+    {
         time_stamp();
         (write(args), ...);
         newLine();
     }
 
 
-    template<typename int_like>
+    template <typename int_like>
         requires is_int_like_v<int_like> && (!is_same_v<int_like, char>)
-    void logHex(int_like val, const char *val_name = "") {
-        if (art_string::strlen(val_name) > 0) {
+    void logHex(int_like val, const char* val_name = "")
+    {
+        if (art_string::strlen(val_name) > 0)
+        {
             write(val_name);
             write(": ");
         }
@@ -147,6 +159,6 @@ public:
     };
 };
 
-Serial &get_serial();
+Serial& get_serial();
 
 #endif //SERIAL_H

--- a/Generic/sys/Communication/Serial.h
+++ b/Generic/sys/Communication/Serial.h
@@ -29,49 +29,72 @@ class ArtFile;
 
 #define PORT 0x3f8          // COM1
 
-class Serial : public StorageDevice
-{
+class Serial : public StorageDevice {
 private:
     static char _read_one_byte();
+
     static void _send_one_byte(unsigned char a);
+
     static int _get_read_ready_status();
+
     static int _get_transmit_empty();
-    static void _write_buffer(const char* data, size_t size);
+
+    static void _write_buffer(const char *data, size_t size);
+
     char name[11] = "/dev/com1";
 
 public:
     Serial();
+
     void link_file();
+
     // ~Serial();
 
     // static Serial& get();
-    ArtFile*& get_file();
+    ArtFile *&get_file();
 
     // remove copy functionality
-    Serial(Serial const& other) = delete;
-    Serial& operator=(Serial const& other) = delete;
+    Serial(Serial const &other) = delete;
+
+    Serial &operator=(Serial const &other) = delete;
 
     bool connected;
+
     void register_device();
+
     void newLine();
+
     void write(bool b);
+
     // void write(unsigned char c);
     void write(char c);
-    void write(const char* data);
-    void write(const char* data, size_t len);
-    u32 com_read(char* dest, u32 count);
-    u32 com_write(const char* data, u32 count);
 
-    i64 read(char* dest, [[maybe_unused]] size_t byte_offset, size_t byte_count) override { return com_read(dest, byte_count); }
-    i64 write(const char* data, [[maybe_unused]] size_t byte_offset, size_t byte_count) override { return com_write(data, byte_count); }
+    void write(const char *data);
+
+    void write(const char *data, size_t len);
+
+    u32 com_read(char *dest, u32 count);
+
+    u32 com_write(const char *data, u32 count);
+
+    i64 read(char *dest, [[maybe_unused]] size_t byte_offset, size_t byte_count) override {
+        return com_read(dest, byte_count);
+    }
+
+    i64 write(const char *data, [[maybe_unused]] size_t byte_offset, size_t byte_count) override {
+        return com_write(data, byte_count);
+    }
+
     i64 seek([[maybe_unused]] u64 byte_offset, [[maybe_unused]] int whence) override { return 0; }
-    char* get_name() override { return name; }
+    i64 async_read(char *dest, [[maybe_unused]] size_t byte_offset, size_t byte_count) override { return -1;}
+    bool async_done() override { return true; }
+    virtual i64 async_n_read() { return -1; }
+    char *get_name() override { return name; }
 
 
     int mount() { return 0; }
 
-    ArtFile* find_file([[maybe_unused]] const char* filename) override
-    {
+    ArtFile *find_file([[maybe_unused]] const char *filename) override {
         if (art_string::strcmp(filename, "/dev/com1") == 0) return get_file();
         else return nullptr;
     }
@@ -84,45 +107,38 @@ public:
 
     void time_stamp();
 
-    template <typename int_like>
-        requires is_int_like_v<int_like> && (!is_same_v<int_like, char>) // Any interger like number but not a char or char array.
-    void write(const int_like val, const bool hex = false)
-    {
+    template<typename int_like>
+        requires is_int_like_v<int_like> && (!is_same_v<int_like, char>)
+    // Any interger like number but not a char or char array.
+    void write(const int_like val, const bool hex = false) {
         char out_str[255];
-        if (hex)
-        {
+        if (hex) {
             art_string::hex_from_int(val, out_str, sizeof(val));
-        }
-        else
-        {
+        } else {
             art_string::string_from_int(val, out_str);
         }
         write(out_str);
     }
 
-    template <typename type_t>
-    void log(type_t const& arg1)
-    {
+    template<typename type_t>
+    void log(type_t const &arg1) {
         time_stamp();
         write(arg1);
         newLine();
     }
 
-    template <typename... args_t>
-    void log(args_t&&... args)
-    {
+    template<typename... args_t>
+    void log(args_t &&... args) {
         time_stamp();
         (write(args), ...);
         newLine();
     }
 
 
-    template <typename int_like>
+    template<typename int_like>
         requires is_int_like_v<int_like> && (!is_same_v<int_like, char>)
-    void logHex(int_like val, const char* val_name = "")
-    {
-        if (art_string::strlen(val_name) > 0)
-        {
+    void logHex(int_like val, const char *val_name = "") {
+        if (art_string::strlen(val_name) > 0) {
             write(val_name);
             write(": ");
         }
@@ -131,6 +147,6 @@ public:
     };
 };
 
-Serial& get_serial();
+Serial &get_serial();
 
 #endif //SERIAL_H

--- a/Generic/sys/Communication/Serial.h
+++ b/Generic/sys/Communication/Serial.h
@@ -86,8 +86,8 @@ public:
     }
 
     i64 seek([[maybe_unused]] u64 byte_offset, [[maybe_unused]] int whence) override { return 0; }
-    i64 async_read(char *dest, [[maybe_unused]] size_t byte_offset, size_t byte_count) override { return -1;}
-    bool async_done() override { return true; }
+    i64 async_read(char* dest, [[maybe_unused]] size_t byte_offset, size_t byte_count) override { return -1; }
+    bool device_busy() override { return false; }
     virtual i64 async_n_read() { return -1; }
     char *get_name() override { return name; }
 

--- a/Generic/sys/FileSystem/ArtFile.cpp
+++ b/Generic/sys/FileSystem/ArtFile.cpp
@@ -89,7 +89,6 @@ bool ArtFile::device_busy() const
 /* return new position in bytes or <0 = error */
 _PDCLIB_int_least64_t ArtFile::seek(const u64 byte_offset, const int whence)
 {
-    // while (device_busy()){}
     if (byte_offset > size - 1) return EOF;
     switch (whence)
     {

--- a/Generic/sys/FileSystem/ArtFile.cpp
+++ b/Generic/sys/FileSystem/ArtFile.cpp
@@ -49,7 +49,11 @@ ArtFile::ArtFile(StorageDevice *dev, char *tmp_filename): device(dev) {
 }
 
 /* return number of bytes read or <0 = error */
-size_t ArtFile::read(char *dest, size_t byte_count) {
+size_t ArtFile::read(char* dest, size_t byte_count)
+{
+    while (device_busy())
+    {
+    }
     // TODO: handle checks here.
     // if (byte_count > 1024*64) {byte_count = 1024*64;}
     if (seek_pos + byte_count > size) { byte_count = size - seek_pos; }
@@ -74,8 +78,9 @@ int ArtFile::start_async_read(char *dest, size_t byte_count) const {
 
 }
 
-bool ArtFile::async_done() const {
-    return device->async_done();
+bool ArtFile::device_busy() const
+{
+    return device->device_busy();
 }
 
 
@@ -102,7 +107,11 @@ _PDCLIB_int_least64_t ArtFile::seek(const u64 byte_offset, const int whence) {
 }
 
 /* return number of bytes written or <0 = error */
-int ArtFile::write(const char *src, const size_t byte_count) {
+int ArtFile::write(const char* src, const size_t byte_count)
+{
+    while (device_busy())
+    {
+    }
     return device->write(src, seek_pos, byte_count);
 }
 

--- a/Generic/sys/FileSystem/ArtFile.cpp
+++ b/Generic/sys/FileSystem/ArtFile.cpp
@@ -30,8 +30,7 @@
 #include "art_string.h"
 
 
-ArtFile::ArtFile(ArtDirectory* parent, const FileData& data) : parent_directory(parent)
-{
+ArtFile::ArtFile(ArtDirectory *parent, const FileData &data) : parent_directory(parent) {
     device = data.device;
     first_byte = data.LBA_address * device->get_block_size();
     size = data.data_length_LE; // bytes
@@ -40,19 +39,17 @@ ArtFile::ArtFile(ArtDirectory* parent, const FileData& data) : parent_directory(
     filename = data.filename;
 }
 
-ArtFile::ArtFile(StorageDevice* dev, char* tmp_filename): device(dev)
-{
+ArtFile::ArtFile(StorageDevice *dev, char *tmp_filename): device(dev) {
     first_byte = 0;
     size = -1; // bytes
     RTC::get().getTime(&datetime);
     file_name_length = art_string::strlen(tmp_filename);
-    filename = static_cast<char*>(art_alloc(file_name_length + 1));
+    filename = static_cast<char *>(art_alloc(file_name_length + 1));
     art_string::strcpy(filename, tmp_filename);
 }
 
 /* return number of bytes read or <0 = error */
-size_t ArtFile::read(char* dest, size_t byte_count)
-{
+size_t ArtFile::read(char *dest, size_t byte_count) {
     // TODO: handle checks here.
     // if (byte_count > 1024*64) {byte_count = 1024*64;}
     if (seek_pos + byte_count > size) { byte_count = size - seek_pos; }
@@ -64,40 +61,55 @@ size_t ArtFile::read(char* dest, size_t byte_count)
     return rc;
 }
 
+int ArtFile::start_async_read(char *dest, size_t byte_count) const {
+    // TODO: handle checks here.
+    // if (byte_count > 1024*64) {byte_count = 1024*64;}
+
+
+    if (seek_pos + byte_count > size) { byte_count = size - seek_pos; }
+    if (byte_count == 0) { return 0; }
+    // TODO: figure out what this should return.
+    // calculates position in disk from start position of file + seek pos
+    return device->async_read(dest, first_byte + seek_pos, byte_count);
+
+}
+
+bool ArtFile::async_done() const {
+    return device->async_done();
+}
+
+
 /* return new position in bytes or <0 = error */
-_PDCLIB_int_least64_t ArtFile::seek(const u64 byte_offset, const int whence)
-{
+_PDCLIB_int_least64_t ArtFile::seek(const u64 byte_offset, const int whence) {
     if (byte_offset > size - 1) return EOF;
-    switch (whence)
-    {
-    case SEEK_SET:
-        {
+    switch (whence) {
+        case SEEK_SET: {
             seek_pos = byte_offset;
             break;
         }
-    case SEEK_CUR:
-        {
+        case SEEK_CUR: {
             seek_pos += byte_offset;
             break;
         }
-    case SEEK_END:
-        {
+        case SEEK_END: {
             seek_pos = size - byte_offset - 1;
             break;
         }
-    default: return -1;
+        default: return -1;
     }
     return seek_pos;
     // TODO: handle checks here.
 }
 
 /* return number of bytes written or <0 = error */
-int ArtFile::write(const char* src, const size_t byte_count)
-{
+int ArtFile::write(const char *src, const size_t byte_count) {
     return device->write(src, seek_pos, byte_count);
 }
 
-const char* ArtFile::get_name()
-{
+const char *ArtFile::get_name() {
     return filename;
+}
+
+i64 ArtFile::async_n_read() {
+    return device->async_n_read();
 }

--- a/Generic/sys/FileSystem/ArtFile.cpp
+++ b/Generic/sys/FileSystem/ArtFile.cpp
@@ -30,7 +30,8 @@
 #include "art_string.h"
 
 
-ArtFile::ArtFile(ArtDirectory *parent, const FileData &data) : parent_directory(parent) {
+ArtFile::ArtFile(ArtDirectory* parent, const FileData& data) : parent_directory(parent)
+{
     device = data.device;
     first_byte = data.LBA_address * device->get_block_size();
     size = data.data_length_LE; // bytes
@@ -39,12 +40,13 @@ ArtFile::ArtFile(ArtDirectory *parent, const FileData &data) : parent_directory(
     filename = data.filename;
 }
 
-ArtFile::ArtFile(StorageDevice *dev, char *tmp_filename): device(dev) {
+ArtFile::ArtFile(StorageDevice* dev, char* tmp_filename): device(dev)
+{
     first_byte = 0;
     size = -1; // bytes
     RTC::get().getTime(&datetime);
     file_name_length = art_string::strlen(tmp_filename);
-    filename = static_cast<char *>(art_alloc(file_name_length + 1));
+    filename = static_cast<char*>(art_alloc(file_name_length + 1));
     art_string::strcpy(filename, tmp_filename);
 }
 
@@ -65,7 +67,8 @@ size_t ArtFile::read(char* dest, size_t byte_count)
     return rc;
 }
 
-int ArtFile::start_async_read(char *dest, size_t byte_count) const {
+int ArtFile::start_async_read(char* dest, size_t byte_count) const
+{
     // TODO: handle checks here.
     // if (byte_count > 1024*64) {byte_count = 1024*64;}
 
@@ -75,7 +78,6 @@ int ArtFile::start_async_read(char *dest, size_t byte_count) const {
     // TODO: figure out what this should return.
     // calculates position in disk from start position of file + seek pos
     return device->async_read(dest, first_byte + seek_pos, byte_count);
-
 }
 
 bool ArtFile::device_busy() const
@@ -85,22 +87,28 @@ bool ArtFile::device_busy() const
 
 
 /* return new position in bytes or <0 = error */
-_PDCLIB_int_least64_t ArtFile::seek(const u64 byte_offset, const int whence) {
+_PDCLIB_int_least64_t ArtFile::seek(const u64 byte_offset, const int whence)
+{
+    // while (device_busy()){}
     if (byte_offset > size - 1) return EOF;
-    switch (whence) {
-        case SEEK_SET: {
+    switch (whence)
+    {
+    case SEEK_SET:
+        {
             seek_pos = byte_offset;
             break;
         }
-        case SEEK_CUR: {
+    case SEEK_CUR:
+        {
             seek_pos += byte_offset;
             break;
         }
-        case SEEK_END: {
+    case SEEK_END:
+        {
             seek_pos = size - byte_offset - 1;
             break;
         }
-        default: return -1;
+    default: return -1;
     }
     return seek_pos;
     // TODO: handle checks here.
@@ -115,10 +123,12 @@ int ArtFile::write(const char* src, const size_t byte_count)
     return device->write(src, seek_pos, byte_count);
 }
 
-const char *ArtFile::get_name() {
+const char* ArtFile::get_name()
+{
     return filename;
 }
 
-i64 ArtFile::async_n_read() {
+i64 ArtFile::async_n_read()
+{
     return device->async_n_read();
 }

--- a/Generic/sys/FileSystem/ArtFile.h
+++ b/Generic/sys/FileSystem/ArtFile.h
@@ -38,9 +38,13 @@ public:
 
 
     size_t read(char* dest, size_t byte_count);
+    int start_async_read(char* dest, size_t byte_count) const;
+    bool async_done() const;
     _PDCLIB_int_least64_t seek(u64 byte_offset, int whence);
     int write(const char* src, size_t byte_count);
     const char* get_name();
+
+    i64 async_n_read();
 
 private:
     ArtDirectory* parent_directory;

--- a/Generic/sys/FileSystem/ArtFile.h
+++ b/Generic/sys/FileSystem/ArtFile.h
@@ -39,7 +39,7 @@ public:
 
     size_t read(char* dest, size_t byte_count);
     int start_async_read(char* dest, size_t byte_count) const;
-    bool async_done() const;
+    bool device_busy() const;
     _PDCLIB_int_least64_t seek(u64 byte_offset, int whence);
     int write(const char* src, size_t byte_count);
     const char* get_name();

--- a/Generic/sys/FileSystem/Files.cpp
+++ b/Generic/sys/FileSystem/Files.cpp
@@ -41,27 +41,33 @@ constexpr int ERR_HANDLE_TAKEN = -2;
 constexpr int ERR_NOT_FOUND = -3;
 
 // TODO: replace with linked list?
-static ArtFile *handles[MAX_HANDLES] = {nullptr};
+static ArtFile* handles[MAX_HANDLES] = {nullptr};
 
-LinkedList<StorageDevice *> devices;
+LinkedList<StorageDevice*> devices;
 
-void register_storage_device(StorageDevice *dev) {
+void register_storage_device(StorageDevice* dev)
+{
     LOG("Storage device registered: ", dev->get_name());
     devices.append(dev);
 }
 
-void deregister_storage_device(StorageDevice *dev) {
+void deregister_storage_device(StorageDevice* dev)
+{
     devices.remove(dev);
 }
 
-ArtFile *get_file_handle(int fd) {
+ArtFile* get_file_handle(int fd)
+{
     return handles[fd];
 }
 
-int find_free_handle() {
+int find_free_handle()
+{
     // skip stderr, stdin, stdout
-    for (size_t i = 3; i < MAX_HANDLES; i++) {
-        if (handles[i] == NULL) {
+    for (size_t i = 3; i < MAX_HANDLES; i++)
+    {
+        if (handles[i] == NULL)
+        {
             return i;
         }
     }
@@ -69,13 +75,16 @@ int find_free_handle() {
 }
 
 
-void close_file_handle(int fd) {
+void close_file_handle(int fd)
+{
     delete handles[fd];
     handles[fd] = NULL;
 }
 
-int register_file_handle(size_t file_id, ArtFile *file) {
-    if (handles[file_id] != NULL) {
+int register_file_handle(size_t file_id, ArtFile* file)
+{
+    if (handles[file_id] != NULL)
+    {
         return ERR_HANDLE_TAKEN;
     }
 
@@ -83,31 +92,38 @@ int register_file_handle(size_t file_id, ArtFile *file) {
     return 0;
 }
 
-int override_file_handle(size_t file_id, ArtFile *file) {
+int override_file_handle(size_t file_id, ArtFile* file)
+{
     handles[file_id] = file;
     return 0;
 }
 
 extern "C"
-int art_open(const char *filename, [[maybe_unused]] unsigned int mode) {
+int art_open(const char* filename, [[maybe_unused]] unsigned int mode)
+{
     // TODO this is unfinished. This should take a path or a working dir
     if (art_string::strcmp("stdin\0", filename) == 0) return 0;
     if (art_string::strcmp("stdout\0", filename) == 0) return 1;
     if (art_string::strcmp("stderr\0", filename) == 0) return 2;
 
-    if (art_string::strcmp("/dev/com1\0", filename) == 0) {
+    if (art_string::strcmp("/dev/com1\0", filename) == 0)
+    {
         int fd = find_free_handle();
-        if (int err = register_file_handle(fd, get_serial().get_file()); err != 0) {
+        if (int err = register_file_handle(fd, get_serial().get_file()); err != 0)
+        {
             return err;
         }
         return fd;
     }
 
-    if (auto *file = devices.find_first<ArtFile *>([filename](StorageDevice *dev) {
+    if (auto* file = devices.find_first<ArtFile*>([filename](StorageDevice* dev)
+    {
         return dev->find_file(filename);
-    })) {
+    }))
+    {
         int file_id = find_free_handle();
-        if (const int err = register_file_handle(file_id, file); err != 0) {
+        if (const int err = register_file_handle(file_id, file); err != 0)
+        {
             return err;
         }
         return file_id;
@@ -117,8 +133,10 @@ int art_open(const char *filename, [[maybe_unused]] unsigned int mode) {
 }
 
 extern "C"
-int art_close(size_t file_id) {
-    if (handles[file_id] != NULL) {
+int art_close(size_t file_id)
+{
+    if (handles[file_id] != NULL)
+    {
         return 0;
     }
     return ERR_NOT_FOUND;
@@ -126,9 +144,11 @@ int art_close(size_t file_id) {
 
 
 extern "C"
-int art_write(const int fd, const char *buf, const unsigned long count) {
-    ArtFile *h = get_file_handle(fd);
-    if (h == NULL) {
+int art_write(const int fd, const char* buf, const unsigned long count)
+{
+    ArtFile* h = get_file_handle(fd);
+    if (h == NULL)
+    {
         // unknown FD
         return -1;
     }
@@ -136,9 +156,11 @@ int art_write(const int fd, const char *buf, const unsigned long count) {
 }
 
 extern "C"
-int art_read(const int file_id, char *buf, const size_t count) {
-    ArtFile *h = get_file_handle(file_id);
-    if (h == NULL) {
+int art_read(const int file_id, char* buf, const size_t count)
+{
+    ArtFile* h = get_file_handle(file_id);
+    if (h == NULL)
+    {
         // unknown FD
         return -1;
     }
@@ -146,9 +168,11 @@ int art_read(const int file_id, char *buf, const size_t count) {
 }
 
 extern "C"
-int art_async_read(const int file_id, char *buf, const size_t count) {
-    ArtFile *h = get_file_handle(file_id);
-    if (h == NULL) {
+int art_async_read(const int file_id, char* buf, const size_t count)
+{
+    ArtFile* h = get_file_handle(file_id);
+    if (h == NULL)
+    {
         // unknown FD
         return -1;
     }
@@ -166,9 +190,11 @@ bool art_dev_busy(const int file_id)
     return h->device_busy();
 }
 
-i64 art_async_n_read(const int file_id) {
-    ArtFile *h = get_file_handle(file_id);
-    if (h == NULL) {
+i64 art_async_n_read(const int file_id)
+{
+    ArtFile* h = get_file_handle(file_id);
+    if (h == NULL)
+    {
         // unknown FD
         return false;
     }
@@ -176,18 +202,22 @@ i64 art_async_n_read(const int file_id) {
 }
 
 
-int art_exec(const int fid) {
-    ArtFile *h = get_file_handle(fid);
-    if (auto executable = ELF(h); executable.is_executable()) {
+int art_exec(const int fid)
+{
+    ArtFile* h = get_file_handle(fid);
+    if (auto executable = ELF(h); executable.is_executable())
+    {
         return executable.execute(); // ideally this would return the exit code.
     }
     return -1; // could not execute. Should replace with real error number.
 }
 
 extern "C"
-_PDCLIB_int_least64_t art_seek_stream(const _PDCLIB_file_t *stream, _PDCLIB_int_least64_t offset, const int whence) {
+_PDCLIB_int_least64_t art_seek_stream(const _PDCLIB_file_t* stream, _PDCLIB_int_least64_t offset, const int whence)
+{
     //TODO: implement device seek_pos changes.
-    if (ArtFile *h = handles[stream->handle]) {
+    if (ArtFile* h = handles[stream->handle])
+    {
         return h->seek(offset, whence);
     }
     // if (strcmp(->get_name(), "doom1.wad") == 0)
@@ -198,9 +228,11 @@ _PDCLIB_int_least64_t art_seek_stream(const _PDCLIB_file_t *stream, _PDCLIB_int_
 }
 
 extern "C"
-_PDCLIB_int_least64_t art_seek(int fd, _PDCLIB_int_least64_t offset, const int whence) {
+_PDCLIB_int_least64_t art_seek(int fd, _PDCLIB_int_least64_t offset, const int whence)
+{
     //TODO: implement device seek_pos changes.
-    if (ArtFile *h = handles[fd]) {
+    if (ArtFile* h = handles[fd])
+    {
         return h->seek(offset, whence);
     }
     // if (strcmp(->get_name(), "doom1.wad") == 0)

--- a/Generic/sys/FileSystem/Files.cpp
+++ b/Generic/sys/FileSystem/Files.cpp
@@ -155,13 +155,15 @@ int art_async_read(const int file_id, char *buf, const size_t count) {
     return h->start_async_read(buf, count);
 }
 
-bool art_async_done(const int file_id) {
-    ArtFile *h = get_file_handle(file_id);
-    if (h == NULL) {
+bool art_dev_busy(const int file_id)
+{
+    ArtFile* h = get_file_handle(file_id);
+    if (h == NULL)
+    {
         // unknown FD
         return false;
     }
-    return h->async_done();
+    return h->device_busy();
 }
 
 i64 art_async_n_read(const int file_id) {

--- a/Generic/sys/FileSystem/Files.cpp
+++ b/Generic/sys/FileSystem/Files.cpp
@@ -220,24 +220,15 @@ _PDCLIB_int_least64_t art_seek_stream(const _PDCLIB_file_t* stream, _PDCLIB_int_
     {
         return h->seek(offset, whence);
     }
-    // if (strcmp(->get_name(), "doom1.wad") == 0)
-    // {
-    //     return doom_seek(stream, offset, whence);
-    // }
     return ERR_NOT_FOUND;
 }
 
 extern "C"
 _PDCLIB_int_least64_t art_seek(int fd, _PDCLIB_int_least64_t offset, const int whence)
 {
-    //TODO: implement device seek_pos changes.
     if (ArtFile* h = handles[fd])
     {
         return h->seek(offset, whence);
     }
-    // if (strcmp(->get_name(), "doom1.wad") == 0)
-    // {
-    //     return doom_seek(stream, offset, whence);
-    // }
     return ERR_NOT_FOUND;
 }

--- a/Generic/sys/FileSystem/Files.h
+++ b/Generic/sys/FileSystem/Files.h
@@ -131,7 +131,7 @@ int art_read(int fd, char *buf, size_t count);
 
 int art_async_read(int file_id, char *buf, size_t count);
 
-bool art_async_done(int file_id);
+bool art_dev_busy(int file_id);
 
 i64 art_async_n_read(int file_id);
 

--- a/Generic/sys/FileSystem/Files.h
+++ b/Generic/sys/FileSystem/Files.h
@@ -112,7 +112,6 @@ enum file_open_flags {
     O_TRUNC = 1 << 13,
     O_APPEND = 1 << 14,
     O_CREATE = 1 << 15,
-
 };
 
 enum mmap_flags {
@@ -130,7 +129,13 @@ int art_write(int fd, const char *buf, unsigned long count);
 
 int art_read(int fd, char *buf, size_t count);
 
-int art_exec(const int fid);
+int art_async_read(int file_id, char *buf, size_t count);
+
+bool art_async_done(int file_id);
+
+i64 art_async_n_read(int file_id);
+
+int art_exec(int fid);
 
 _PDCLIB_int_least64_t art_seek_stream(const struct _PDCLIB_file_t *stream, _PDCLIB_int_least64_t offset, int whence);
 

--- a/Generic/sys/Scheduling/IO_Read.cpp
+++ b/Generic/sys/Scheduling/IO_Read.cpp
@@ -1,0 +1,98 @@
+// ArtOS - hobby operating system by Artie Poole
+// Copyright (C) 2025 Stuart Forbes Poole <artiepoole>
+//
+//     This program is free software: you can redistribute it and/or modify
+//     it under the terms of the GNU General Public License as published by
+//     the Free Software Foundation, either version 3 of the License, or
+//     (at your option) any later version.
+//
+//     This program is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//     GNU General Public License for more details.
+//
+//     You should have received a copy of the GNU General Public License
+//     along with this program.  If not, see <https://www.gnu.org/licenses/>
+
+//
+// Created by artiepoole on 7/6/25.
+//
+#include <CPU.h>
+#include <cstdio>
+#include <Files.h>
+#include <paging.h>
+#include <PagingTableKernel.h>
+#include <Process.h>
+
+#include "io_queue_entry.h"
+
+IO_read::IO_read(int* r, const int fd, char* dest, const size_t count)
+{
+    _fd = fd;
+    _buf = dest;
+    const size_t offset_in_page = (reinterpret_cast<uintptr_t>(dest) % page_alignment);
+    _k_buf = reinterpret_cast<char*>(kernel_pages().map_user_to_kernel(
+        reinterpret_cast<uintptr_t>(_buf),
+        count + offset_in_page) + offset_in_page);
+    _count = count;
+    _state = NOT_STARTED;
+    result = r;
+}
+
+IO_operation::IO_State IO_read::state()
+{
+    if (_state == NOT_STARTED && !art_dev_busy(_fd))
+    {
+        _state = READY;
+    }
+    if (_state == IN_PROGRESS)
+    {
+        if (const i64 n_read = art_async_n_read(_fd); n_read == _count)
+        {
+            const size_t offset_in_page = (reinterpret_cast<uintptr_t>(_k_buf) % page_alignment);
+            kernel_pages().unmap_user_to_kernel(reinterpret_cast<uintptr_t>(_k_buf),
+                                                _count + offset_in_page);
+            art_seek(_fd, n_read, SEEK_CUR);
+            *result = static_cast<int>(n_read);
+            _state = DONE;
+        }
+    }
+    return _state;
+}
+
+void IO_read::do_op()
+{
+#if ASYNC_READ
+    switch (const int res = art_async_read(_fd, _k_buf,
+                                           _count))
+    {
+    case -1:
+#if ENABLE_SERIAL_LOGGING and LOG_SYSCALL
+        get_serial().log("Async not enabled, using synchronous read");
+#endif
+        *result = art_read(_fd, _k_buf, _count);
+        _state = DONE;
+        break;
+    case 0:
+#if ENABLE_SERIAL_LOGGING and LOG_SYSCALL
+        get_serial().log("async read started");
+#endif
+        _state = IN_PROGRESS;
+        break;
+    default:
+#if ENABLE_SERIAL_LOGGING and LOG_SYSCALL
+        get_serial().log(res, " bytes of data already in buffer, returning directly");
+#endif
+        *result = res;
+        // If immediate, must seek else the seek happens on complete read.
+        art_seek(_fd, res, SEEK_CUR);
+        _state = DONE;
+        break;
+    }
+#else
+#if ENABLE_SERIAL_LOGGING and LOG_SYSCALL
+    get_serial().log("Async not enabled, using synchronous read");
+#endif
+    *ret = art_read(_fd, _k_buf, _count);
+#endif
+}

--- a/Generic/sys/Scheduling/Process.cpp
+++ b/Generic/sys/Scheduling/Process.cpp
@@ -37,7 +37,6 @@ Process::Process() {
     user = false;
     cr3_val = 0;
     paging_table = nullptr;
-    waiting_data = {NOT_WAITING, -1};
 }
 
 void Process::reset() {
@@ -54,7 +53,6 @@ void Process::reset() {
     }
     user = false;
     cr3_val = 0;
-    waiting_data = {NOT_WAITING, -1};
 }
 
 

--- a/Generic/sys/Scheduling/Process.cpp
+++ b/Generic/sys/Scheduling/Process.cpp
@@ -25,8 +25,7 @@
 #include "EventQueue.h"
 #include "art_string.h"
 
-Process::Process()
-{
+Process::Process() {
     state = STATE_DEAD;
     parent_pid = -1;
     priority = PRIORITY_NORMAL;
@@ -38,10 +37,10 @@ Process::Process()
     user = false;
     cr3_val = 0;
     paging_table = nullptr;
+    waiting_fid = -1;
 }
 
-void Process::reset()
-{
+void Process::reset() {
     state = STATE_DEAD;
     parent_pid = -1;
     priority = PRIORITY_NORMAL;
@@ -49,18 +48,18 @@ void Process::reset()
     context = cpu_registers_t{};
     stack = NULL;
     name[0] = '\0';
-    if (eventQueue != NULL)
-    {
+    if (eventQueue != NULL) {
         delete eventQueue;
         eventQueue = NULL;
     }
     user = false;
     cr3_val = 0;
+    waiting_fid = -1;
 }
 
 
-void Process::start(const size_t parent_id, const cpu_registers_t& new_context, void* new_stack, const char* new_name, const bool is_user)
-{
+void Process::start(const size_t parent_id, const cpu_registers_t &new_context, void *new_stack, const char *new_name,
+                    const bool is_user) {
     LOG("Starting ", new_name);
     parent_pid = parent_id;
     state = STATE_READY;
@@ -74,10 +73,8 @@ void Process::start(const size_t parent_id, const cpu_registers_t& new_context, 
     user = is_user;
 }
 
-Process::~Process()
-{
-    if (eventQueue != NULL)
-    {
+Process::~Process() {
+    if (eventQueue != NULL) {
         delete eventQueue;
     }
 }

--- a/Generic/sys/Scheduling/Process.cpp
+++ b/Generic/sys/Scheduling/Process.cpp
@@ -37,7 +37,7 @@ Process::Process() {
     user = false;
     cr3_val = 0;
     paging_table = nullptr;
-    waiting_fid = -1;
+    waiting_data = {NOT_WAITING, -1};
 }
 
 void Process::reset() {
@@ -54,7 +54,7 @@ void Process::reset() {
     }
     user = false;
     cr3_val = 0;
-    waiting_fid = -1;
+    waiting_data = {NOT_WAITING, -1};
 }
 
 

--- a/Generic/sys/Scheduling/Process.h
+++ b/Generic/sys/Scheduling/Process.h
@@ -44,6 +44,7 @@ struct Process
         STATE_SLEEPING,
         STATE_PARKED,
         STATE_READY,
+        STATE_WAITING,
     };
 
     // Used to scale execution duration.
@@ -69,7 +70,7 @@ struct Process
     PagingTableUser* paging_table;
     uintptr_t cr3_val;
     u64 last_executed;
-
+    int waiting_fid = -1;
 };
 
 

--- a/Generic/sys/Scheduling/Process.h
+++ b/Generic/sys/Scheduling/Process.h
@@ -47,12 +47,26 @@ struct Process
         STATE_WAITING,
     };
 
+    enum WaitingReason_t
+    {
+        NOT_WAITING,
+        FILE_READING,
+        DEV_BUSY,
+        FILE_WRITE,
+    };
+
+    struct waiting_data_t
+    {
+        WaitingReason_t reason = NOT_WAITING;
+        int value = -1; // FID for files
+    };
+
     // Used to scale execution duration.
     enum Priority_t
     {
         PRIORITY_LOW = 1,
-        PRIORITY_NORMAL = 2,
-        PRIORITY_HIGH = 4,
+        PRIORITY_NORMAL = 10,
+        PRIORITY_HIGH = 100,
     };
 
     bool isParked() { return state == STATE_PARKED; }
@@ -70,7 +84,7 @@ struct Process
     PagingTableUser* paging_table;
     uintptr_t cr3_val;
     u64 last_executed;
-    int waiting_fid = -1;
+    waiting_data_t waiting_data = {};
 };
 
 

--- a/Generic/sys/Scheduling/Process.h
+++ b/Generic/sys/Scheduling/Process.h
@@ -44,22 +44,8 @@ struct Process
         STATE_SLEEPING,
         STATE_PARKED,
         STATE_READY,
-        STATE_WAITING,
     };
 
-    enum WaitingReason_t
-    {
-        NOT_WAITING,
-        FILE_READING,
-        DEV_BUSY,
-        FILE_WRITE,
-    };
-
-    struct waiting_data_t
-    {
-        WaitingReason_t reason = NOT_WAITING;
-        int value = -1; // FID for files
-    };
 
     // Used to scale execution duration.
     enum Priority_t
@@ -84,7 +70,6 @@ struct Process
     PagingTableUser* paging_table;
     uintptr_t cr3_val;
     u64 last_executed;
-    waiting_data_t waiting_data = {};
 };
 
 

--- a/Generic/sys/Scheduling/Scheduler.cpp
+++ b/Generic/sys/Scheduling/Scheduler.cpp
@@ -29,6 +29,7 @@
 #include <logging.h>
 #include <PagingTableKernel.h>
 #include <PagingTableUser.h>
+#include <Process.h>
 #include <SMBIOS.h>
 #include <string.h>
 #include <syscall.h>
@@ -43,9 +44,9 @@
 
 #define LOG_IDLE false
 #ifdef NDEBUG
-    #define CONTEXT_SWITCH_PERIOD_US 1000  // Release
+#define CONTEXT_SWITCH_PERIOD_US 100  // Release
 #else
-#define CONTEXT_SWITCH_PERIOD_US 10000 // Debug or other
+#define CONTEXT_SWITCH_PERIOD_US 100 // Debug or other
 #endif
 
 size_t context_switch_period_us = CONTEXT_SWITCH_PERIOD_US;
@@ -60,13 +61,13 @@ struct sleep_timer_t
 size_t stack_alignment = 16;
 
 u32 default_eflags = 0x206;
-Scheduler *scheduler_instance = nullptr;
+Scheduler* scheduler_instance = nullptr;
 u64 execution_counter = 0;
 size_t current_process_id = 0;
 size_t highest_assigned_pid = 0;
 // size_t next_process_id = 1;
 Process processes[max_processes];
-LocalAPIC *lapic_timer = nullptr;
+LocalAPIC* lapic_timer = nullptr;
 
 
 LinkedList<sleep_timer_t> sleep_timers;
@@ -75,20 +76,22 @@ LinkedList<sleep_timer_t> sleep_timers;
 extern u8 kernel_stack_top;
 extern u8 kernel_stack_bottom;
 
-void idle_task() {
-    while (true) {
+void idle_task()
+{
+    while (true)
+    {
     };
 }
 
 
-Scheduler::Scheduler(LocalAPIC *timer, EventQueue *kernel_queue) {
+Scheduler::Scheduler(LocalAPIC* timer, EventQueue* kernel_queue)
+{
     // Store current state in process[0]
     // Set up first Lapic one shot
     // disable_interrupts();
 #if ENABLE_SERIAL_LOGGING
     get_serial().log("context_switch_period_us: ", context_switch_period_us);
 #endif
-    execution_counter = TSC_get_ticks();
     art_string::memset(processes, 0, sizeof(Process) * max_processes);
     scheduler_instance = this;
     lapic_timer = timer;
@@ -102,11 +105,13 @@ Scheduler::Scheduler(LocalAPIC *timer, EventQueue *kernel_queue) {
     // execf(, main_func, name, false);
 }
 
-Scheduler::~Scheduler() {
+Scheduler::~Scheduler()
+{
     scheduler_instance = nullptr;
 }
 
-Scheduler &Scheduler::get() {
+Scheduler& Scheduler::get()
+{
     return *scheduler_instance;
 }
 
@@ -118,69 +123,12 @@ Scheduler &Scheduler::get() {
  * Write values (like initial stack contents, arguments, etc.) via the kernel mapping.
  * Later, when the process runs, load its CR3, set its initial stack pointer, and iret.
 */
-// Create new process. This can only be user mode if the code and data for the function are contained in user-accessible pages
-void Scheduler::execf(cpu_registers_t *r, u32 func, uintptr_t name_loc, const bool user) {
-    auto name = reinterpret_cast<const char *>(name_loc);
-    // Should copy stack contents but I am not sure if they are already ruined by this.R=
-    size_t next_process_id = getNextFreeProcessID();
-    const size_t parent_process_id = current_process_id;
-    if (next_process_id + 1 >= max_processes) return; // TODO: Error
 
-    auto *proc = &processes[next_process_id];
-
-
-    cpu_registers_t context{};
-    proc->user = user;
-    void *proc_stack;
-    void *stack_top;
-    if (user) {
-        proc->paging_table = new PagingTableUser();
-        proc->cr3_val = proc->paging_table->get_phys_addr_of_page_dir();
-        // TOOD: this needs to be replaced so that a malloc call can be done using flags instead.
-        // TODO: the stack must be part of the user space memory map so this has to be remapped!
-        proc_stack = art_alloc(stack_size, stack_alignment);
-        stack_top = static_cast<u8 *>(proc_stack) + stack_size;
-    } else {
-        // proc_stack = art_alloc(stack_size, stack_alignment);
-        // stack_top = static_cast<u8*>(proc_stack) + stack_size;
-        // proc_stack = &kernel_stack_bottom;
-        proc->cr3_val = kernel_pages().get_phys_addr_of_page_dir();
-        stack_top = &kernel_stack_top;
-    }
-    LOG("Starting Process: ", name, " PID: ", next_process_id);
-    context.esp = reinterpret_cast<u32>(stack_top);
-
-    if (user) {
-        context.cs = user_cs_offset | RPL_USER;
-        context.ds = user_ds_offset | RPL_USER;
-        context.es = user_ds_offset | RPL_USER;
-        context.fs = user_ds_offset | RPL_USER;
-        context.gs = user_ds_offset | RPL_USER;
-        context.ss = user_ds_offset | RPL_USER;
-    } else {
-        context.cs = kernel_cs_offset;
-        context.ds = kernel_ds_offset;
-        context.es = kernel_ds_offset;
-        context.fs = kernel_ds_offset;
-        context.gs = kernel_ds_offset;
-        context.ss = kernel_ds_offset;
-    }
-    context.eip = func;
-    context.eflags = default_eflags;
-
-    proc->last_executed = TSC_get_ticks();
-    proc->start(parent_process_id, context, proc_stack, name, user);
-
-    processes[parent_process_id].state = Process::STATE_PARKED;
-    schedule(r);
-}
-
-
-// TODO (URGENT): This should swap paging directory. See: https://wiki.osdev.org/Kernel_Multitasking#Kernel_Stack_Per_Task
-// Specifically the `cmp eax,ecx` lines.
-void Scheduler::switch_process(cpu_registers_t *const r, size_t new_PID) {
+void Scheduler::switch_process(cpu_registers_t* const r, size_t new_PID)
+{
     // This should just pop the stack and push to it to replace next process. If process is 0 idk what to do.
-    if (new_PID == 0) {
+    if (new_PID == 0)
+    {
         new_PID = 1;
     }
 
@@ -201,7 +149,8 @@ void Scheduler::switch_process(cpu_registers_t *const r, size_t new_PID) {
     set_current_context(r, current_process_id);
 }
 
-size_t Scheduler::getNextFreeProcessID() {
+size_t Scheduler::getNextFreeProcessID()
+{
     size_t ret_id = 0;
     while (processes[ret_id].state != Process::STATE_DEAD) { ret_id++; }
     if (ret_id > highest_assigned_pid) highest_assigned_pid = ret_id;
@@ -209,55 +158,91 @@ size_t Scheduler::getNextFreeProcessID() {
 }
 
 // Returns the id of the process which is parked or alive which has the highest id.
-size_t Scheduler::getMaxAliveProcessID() {
+size_t Scheduler::getMaxAliveProcessID()
+{
     size_t ret_id = 0;
-    for (size_t i = 0; i <= highest_assigned_pid; i++) {
+    for (size_t i = 0; i <= highest_assigned_pid; i++)
+    {
         if (processes[i].state != Process::STATE_DEAD || processes[i].state != Process::STATE_EXITED) ret_id = i;
     }
     if (highest_assigned_pid < ret_id) highest_assigned_pid = ret_id;
     return ret_id;
 }
 
-// size_t Scheduler::getCurrentProcessID()
-// {
-// }
 
-
-void Scheduler::clean_up_exited_threads() {
-    for (size_t i = 0; i <= highest_assigned_pid; i++) {
-        if (processes[i].state == Process::STATE_EXITED) {
-            if (processes[i].user) {
+void Scheduler::clean_up_exited_threads()
+{
+    for (size_t i = 0; i <= highest_assigned_pid; i++)
+    {
+        if (processes[i].state == Process::STATE_EXITED)
+        {
+            if (processes[i].user)
+            {
                 art_free(processes[i].stack);
             }
             processes[i].reset(); // cleans up event queue.
-            if (i == highest_assigned_pid) {
+            if (i == highest_assigned_pid)
+            {
                 highest_assigned_pid = getMaxAliveProcessID();
             }
         }
     }
 }
 
-void Scheduler::check_finished_io_read() {
-    for (size_t i = 0; i <= highest_assigned_pid; i++) {
-        if (Process &proc = processes[i]; proc.state == Process::STATE_WAITING) {
-            if (proc.waiting_fid > 0 && art_async_done(proc.waiting_fid)) {
-                proc.state = Process::STATE_READY;
-                proc.context.eax = art_async_n_read(proc.waiting_fid);
-                proc.waiting_fid = -1;
+void Scheduler::check_finished_io()
+{
+    for (size_t i = 0; i <= highest_assigned_pid; i++)
+    {
+        if (Process& proc = processes[i]; proc.state == Process::STATE_WAITING)
+        {
+            switch (auto [reason, value] = proc.waiting_data; reason)
+            {
+            case Process::NOT_WAITING: continue;
+            case Process::FILE_READING:
+                {
+#if ASYNC_READ
+                    if (!art_dev_busy(value))
+                    {
+                        proc.state = Process::STATE_READY;
+                        proc.context.eax = art_async_n_read(value);
+                        proc.waiting_data.value = -1;
+                    }
+#endif
+
+                    break;
+                }
+            case Process::DEV_BUSY:
+                {
+                    if (!art_dev_busy(value))
+                    {
+#if ENABLE_SERIAL_LOGGING
+                        get_serial().log("Device marked as not busy. No idea if this will work.");
+#endif
+                        proc.state = Process::STATE_READY;
+                        // TODO: how to retry the read?
+                        syscall_handler(&proc.context);
+                    }
+                    break;
+                }
+            default:
+                break;
             }
         }
     }
 }
 
-size_t Scheduler::getCurrentProcessID() {
+size_t Scheduler::getCurrentProcessID()
+{
     return current_process_id;
 }
 
-EventQueue *Scheduler::getCurrentProcessEventQueue() {
+EventQueue* Scheduler::getCurrentProcessEventQueue()
+{
     return processes[current_process_id].eventQueue;
 }
 
-uintptr_t Scheduler::getCurrentProcessPagingDirectory() {
+uintptr_t Scheduler::getCurrentProcessPagingDirectory()
+{
     return processes[current_process_id].paging_table->get_phys_addr_of_page_dir();
 }
 
@@ -285,12 +270,15 @@ void handle_expired_timers()
     }
 }
 
-size_t get_oldest_process() {
+size_t get_oldest_process()
+{
     size_t ret_id = 0;
     u64 lowest = -1;
-    for (size_t i = 2; i <= highest_assigned_pid; i++) {
+    for (size_t i = 2; i <= highest_assigned_pid; i++)
+    {
         if (processes[i].state != Process::STATE_READY) continue;
-        if (processes[i].last_executed < lowest) {
+        if (processes[i].last_executed < lowest)
+        {
             ret_id = i;
             lowest = processes[i].last_executed;
         }
@@ -299,13 +287,16 @@ size_t get_oldest_process() {
     return ret_id;
 }
 
-size_t Scheduler::getNextProcessID() {
+size_t Scheduler::getNextProcessID()
+{
     const size_t next = get_oldest_process(); // dec and return split here for debugging purposes.
     return next;
 }
 
-void Scheduler::start_oneshot(u32 time_us) {
-    if (lapic_timer->start_timer_us(time_us) < 0) {
+void Scheduler::start_oneshot(u32 time_us)
+{
+    if (lapic_timer->start_timer_us(time_us) < 0)
+    {
 #if ENABLE_SERIAL_LOGGING
         get_serial().log("Lapic failed to start timer?");
 #endif
@@ -313,16 +304,19 @@ void Scheduler::start_oneshot(u32 time_us) {
 }
 
 //TODO: refactor. this no longer converts
-void Scheduler::store_current_context(cpu_registers_t *r, const size_t PID) {
+void Scheduler::store_current_context(cpu_registers_t* r, const size_t PID)
+{
     art_string::memcpy(&processes[PID].context, r, sizeof(cpu_registers_t));
 }
 
-void Scheduler::set_current_context(cpu_registers_t *r, size_t PID) {
+void Scheduler::set_current_context(cpu_registers_t* r, size_t PID)
+{
     art_string::memcpy(r, &processes[PID].context, sizeof(cpu_registers_t));
     asm volatile("mov %0, %%cr3" :: "r"(processes[PID].cr3_val) : "memory");
 }
 
-void Scheduler::sleep_ms(cpu_registers_t *r) {
+void Scheduler::sleep_ms(cpu_registers_t* r)
+{
     const size_t ms = r->ebx;
     sleep_timers.append(sleep_timer_t{current_process_id, ms});
     processes[current_process_id].state = Process::STATE_SLEEPING;
@@ -331,33 +325,37 @@ void Scheduler::sleep_ms(cpu_registers_t *r) {
     schedule(r);
 }
 
-void Scheduler::mark_process_as_waiting(cpu_registers_t *r) {
-    const int fd = r->ebx;
+void Scheduler::mark_process_as_waiting(cpu_registers_t* r, const Process::WaitingReason_t reason, const int data)
+{
     processes[current_process_id].state = Process::STATE_WAITING;
-    processes[current_process_id].waiting_fid = fd;
+    processes[current_process_id].waiting_data = {reason, data};
     schedule(r);
 }
 
 // When called from interrupt, the state is stored at this pointer loc, r.
-void Scheduler::schedule(cpu_registers_t *const r) {
+void Scheduler::schedule(cpu_registers_t* const r)
+{
     clean_up_exited_threads();
     handle_expired_timers();
-    check_finished_io_read();
+    check_finished_io();
     const size_t next_id = getNextProcessID();
     switch_process(r, next_id);
 }
 
 
-void LAPIC_handler(cpu_registers_t *const r) {
+void LAPIC_handler(cpu_registers_t* const r)
+{
     Scheduler::schedule(r);
     // TODO: implement scheduler
 }
 
 // Exit is called by the program to tell the OS it is done.
-void Scheduler::exit(cpu_registers_t *const r) {
+void Scheduler::exit(cpu_registers_t* const r)
+{
     u32 status = r->ebx;
     LOG("Exiting ", processes[current_process_id].name, " PID: ", current_process_id, " with status: ", status);
-    if (current_process_id == 2) {
+    if (current_process_id == 2)
+    {
         const int shell_file = art_open("b.art", 0);
         if (shell_file < 1) { LOG("CRITICAL: Failed to restart b.art"); }
         art_exec(shell_file);
@@ -366,7 +364,8 @@ void Scheduler::exit(cpu_registers_t *const r) {
     }
     processes[current_process_id].state = Process::STATE_EXITED;
     auto parent_id = processes[current_process_id].parent_pid;
-    if (processes[parent_id].state == Process::STATE_PARKED) {
+    if (processes[parent_id].state == Process::STATE_PARKED)
+    {
         processes[parent_id].state = Process::STATE_READY;
         processes[parent_id].context.eax = status;
     }
@@ -376,10 +375,12 @@ void Scheduler::exit(cpu_registers_t *const r) {
 }
 
 // Kill is supposed to send a command to the process to tell it to exit.
-void Scheduler::kill(size_t target_pid) {
+void Scheduler::kill(size_t target_pid)
+{
     processes[target_pid].state = Process::STATE_EXITED;
     auto parent_id = processes[current_process_id].parent_pid;
-    if (processes[parent_id].state == Process::STATE_PARKED) {
+    if (processes[parent_id].state == Process::STATE_PARKED)
+    {
         processes[parent_id].state = Process::STATE_READY;
     }
     // ???? what do here? I cannot switch because then it never returns?
@@ -387,10 +388,11 @@ void Scheduler::kill(size_t target_pid) {
     // kyield();
 }
 
-void Scheduler::create_idle_task() {
+void Scheduler::create_idle_task()
+{
     const size_t next_process_id = getNextFreeProcessID();
     if (next_process_id + 1 >= max_processes) return; // TODO: Error
-    auto *proc = &processes[next_process_id];
+    auto* proc = &processes[next_process_id];
     cpu_registers_t context{};
 
     context.cs = kernel_cs_offset;
@@ -418,30 +420,34 @@ void Scheduler::create_idle_task() {
     proc->cr3_val = kernel_pages().get_phys_addr_of_page_dir();
 }
 
-void Scheduler::execute_from_paging_table(PagingTableUser *PTU, const char *name_loc, const uintptr_t entry_point,
-                                          const uintptr_t stack_vaddr, const uintptr_t stack_size) {
+void Scheduler::execute_from_paging_table(PagingTableUser* PTU, const char* name_loc, const uintptr_t entry_point,
+                                          const uintptr_t stack_vaddr, const uintptr_t stack_size)
+{
     auto name = name_loc;
     // Should copy stack contents but I am not sure if they are already ruined by this.R=
     size_t next_process_id = getNextFreeProcessID();
     const size_t parent_process_id = current_process_id;
     if (next_process_id + 1 >= max_processes) return; // TODO: Error
 
-    auto *proc = &processes[next_process_id];
+    auto* proc = &processes[next_process_id];
     *proc = Process{};
 
     cpu_registers_t context{};
     proc->user = true;
     proc->paging_table = PTU;
     uintptr_t stack_top;
-    void *proc_stack;
+    void* proc_stack;
 
     // TOOD: this needs to be replaced so that a malloc call can be done using flags instead.
     // TODO: the stack must be part of the user space memory map so this has to be remapped!
-    if (stack_size == 0 or stack_vaddr == 0) {
+    if (stack_size == 0 or stack_vaddr == 0)
+    {
         proc_stack = art_alloc(stack_size, stack_alignment);
         stack_top = reinterpret_cast<uintptr_t>(proc_stack) + stack_size;
-    } else {
-        proc_stack = reinterpret_cast<u8 *>(stack_vaddr);
+    }
+    else
+    {
+        proc_stack = reinterpret_cast<u8*>(stack_vaddr);
         stack_top = stack_vaddr + stack_size;
     }
 
@@ -464,6 +470,7 @@ void Scheduler::execute_from_paging_table(PagingTableUser *PTU, const char *name
     processes[parent_process_id].state = Process::STATE_PARKED;
 }
 
-PagingTableUser &Scheduler::getCurrentPagingTable() {
+PagingTableUser& Scheduler::getCurrentPagingTable()
+{
     return *processes[current_process_id].paging_table;
 }

--- a/Generic/sys/Scheduling/Scheduler.h
+++ b/Generic/sys/Scheduling/Scheduler.h
@@ -21,6 +21,7 @@
 #ifndef SCHEDULER_H
 #define SCHEDULER_H
 
+#include <io_queue_entry.h>
 #include <LocalAPIC.h>
 #include <Process.h>
 
@@ -40,58 +41,37 @@ public:
     ~Scheduler();
 
     static Scheduler& get();
-
-    // void start(size_t PID);
-    // static void switch_process(size_t new_PID);
-    static void switch_process(cpu_registers_t* r, size_t new_PID);
-
     static size_t getNextFreeProcessID();
-
     static size_t getMaxAliveProcessID();
-
-    // Only takes void foo() types atm. No support for input variables
-    static void execf(cpu_registers_t* r, uintptr_t func, uintptr_t name, bool user);
-
-    // static void fork();
+    static void handle_expired_timers();
     static void exit(cpu_registers_t* r);
-
     static void kill(size_t target_pid);
-
-    static void create_idle_task();
 
     static void execute_from_paging_table(PagingTableUser* PTU, const char* name_loc, uintptr_t entry_point,
                                           uintptr_t stack_vaddr, uintptr_t stack_size);
-
     PagingTableUser& getCurrentPagingTable();
 
-    static void clean_up_exited_threads();
-
-    static void check_finished_io();
-
     static size_t getCurrentProcessID();
-
     static EventQueue* getCurrentProcessEventQueue();
-
     static uintptr_t getCurrentProcessPagingDirectory();
-
-    // static bool isCurrentProcessUser();
-    // static bool isProcessUser(size_t PID);
     static size_t getNextProcessID();
-
     static void start_oneshot(u32 time_us);
-
-    // static void store_current_context(size_t PID);
-    static void store_current_context(cpu_registers_t* r, size_t PID);
-
-    static void set_current_context(cpu_registers_t* r, size_t PID);
-
     static void schedule(cpu_registers_t* r);
 
     // static void schedule();
 
     static void sleep_ms(cpu_registers_t* r);
+    static void append_read(cpu_registers_t* r);
 
-    static void mark_process_as_waiting(cpu_registers_t* r, Process::WaitingReason_t reason, int data);
+private:
+    static void create_idle_task();
+
+    static void handle_exited_threads();
+    static void handle_io();
+    static size_t get_next_process_id();
+    static void switch_process(cpu_registers_t* r, size_t new_PID);
+    static void store_current_context(cpu_registers_t* r, size_t PID);
+    static void set_current_context(cpu_registers_t* r, size_t PID);
 };
 
 

--- a/Generic/sys/Scheduling/Scheduler.h
+++ b/Generic/sys/Scheduling/Scheduler.h
@@ -22,6 +22,7 @@
 #define SCHEDULER_H
 
 #include <LocalAPIC.h>
+#include <Process.h>
 
 #include  "types.h"
 
@@ -31,44 +32,45 @@ constexpr size_t max_processes = 255;
 class EventQueue;
 class PagingTableUser;
 
-class Scheduler {
+class Scheduler
+{
 public:
-    Scheduler(LocalAPIC *timer, EventQueue *kernel_queue);
+    Scheduler(LocalAPIC* timer, EventQueue* kernel_queue);
 
     ~Scheduler();
 
-    static Scheduler &get();
+    static Scheduler& get();
 
     // void start(size_t PID);
     // static void switch_process(size_t new_PID);
-    static void switch_process(cpu_registers_t *r, size_t new_PID);
+    static void switch_process(cpu_registers_t* r, size_t new_PID);
 
     static size_t getNextFreeProcessID();
 
     static size_t getMaxAliveProcessID();
 
     // Only takes void foo() types atm. No support for input variables
-    static void execf(cpu_registers_t *r, uintptr_t func, uintptr_t name, bool user);
+    static void execf(cpu_registers_t* r, uintptr_t func, uintptr_t name, bool user);
 
     // static void fork();
-    static void exit(cpu_registers_t *r);
+    static void exit(cpu_registers_t* r);
 
     static void kill(size_t target_pid);
 
     static void create_idle_task();
 
-    static void execute_from_paging_table(PagingTableUser *PTU, const char *name_loc, uintptr_t entry_point,
+    static void execute_from_paging_table(PagingTableUser* PTU, const char* name_loc, uintptr_t entry_point,
                                           uintptr_t stack_vaddr, uintptr_t stack_size);
 
-    PagingTableUser &getCurrentPagingTable();
+    PagingTableUser& getCurrentPagingTable();
 
     static void clean_up_exited_threads();
 
-    static void check_finished_io_read();
+    static void check_finished_io();
 
     static size_t getCurrentProcessID();
 
-    static EventQueue *getCurrentProcessEventQueue();
+    static EventQueue* getCurrentProcessEventQueue();
 
     static uintptr_t getCurrentProcessPagingDirectory();
 
@@ -79,17 +81,17 @@ public:
     static void start_oneshot(u32 time_us);
 
     // static void store_current_context(size_t PID);
-    static void store_current_context(cpu_registers_t *r, size_t PID);
+    static void store_current_context(cpu_registers_t* r, size_t PID);
 
-    static void set_current_context(cpu_registers_t *r, size_t PID);
+    static void set_current_context(cpu_registers_t* r, size_t PID);
 
-    static void schedule(cpu_registers_t *r);
+    static void schedule(cpu_registers_t* r);
 
     // static void schedule();
 
-    static void sleep_ms(cpu_registers_t *r);
+    static void sleep_ms(cpu_registers_t* r);
 
-    static void mark_process_as_waiting(cpu_registers_t* r);
+    static void mark_process_as_waiting(cpu_registers_t* r, Process::WaitingReason_t reason, int data);
 };
 
 

--- a/Generic/sys/Scheduling/Scheduler.h
+++ b/Generic/sys/Scheduling/Scheduler.h
@@ -60,9 +60,11 @@ public:
     static void execute_from_paging_table(PagingTableUser *PTU, const char *name_loc, uintptr_t entry_point,
                                           uintptr_t stack_vaddr, uintptr_t stack_size);
 
-    PagingTableUser *getCurrentPagingTable();
+    PagingTableUser &getCurrentPagingTable();
 
     static void clean_up_exited_threads();
+
+    static void check_finished_io_read();
 
     static size_t getCurrentProcessID();
 
@@ -86,6 +88,8 @@ public:
     // static void schedule();
 
     static void sleep_ms(cpu_registers_t *r);
+
+    static void mark_process_as_waiting(cpu_registers_t* r);
 };
 
 

--- a/Generic/sys/Scheduling/io_queue_entry.h
+++ b/Generic/sys/Scheduling/io_queue_entry.h
@@ -1,0 +1,76 @@
+// ArtOS - hobby operating system by Artie Poole
+// Copyright (C) 2025 Stuart Forbes Poole <artiepoole>
+//
+//     This program is free software: you can redistribute it and/or modify
+//     it under the terms of the GNU General Public License as published by
+//     the Free Software Foundation, either version 3 of the License, or
+//     (at your option) any later version.
+//
+//     This program is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//     GNU General Public License for more details.
+//
+//     You should have received a copy of the GNU General Public License
+//     along with this program.  If not, see <https://www.gnu.org/licenses/>
+
+//
+// Created by artiepoole on 7/6/25.
+//
+
+#ifndef IO_QUEUE_ENTRY_H
+#define IO_QUEUE_ENTRY_H
+#include <_types.h>
+
+struct cpu_registers_t;
+
+enum WaitingReason_t
+{
+    NOT_WAITING,
+    FILE_READING,
+    DEV_BUSY,
+    FILE_WRITE,
+};
+
+
+class IO_operation
+{
+public:
+    enum IO_State
+    {
+        NOT_STARTED,
+        READY,
+        IN_PROGRESS,
+        DONE,
+        ERROR,
+    };
+
+    virtual ~IO_operation() = default;
+    virtual IO_State state() = 0;
+    virtual void do_op() = 0;
+    int* result;
+    IO_State _state;
+};
+
+class IO_read final : public IO_operation
+{
+public:
+    IO_read(int* r, int fd, char* dest, size_t count);
+    IO_State state() override;
+    void do_op() override;
+
+private:
+    int _fd;
+    char* _buf;
+    char* _k_buf;
+    size_t _count;
+};
+
+struct io_queue_entry_t
+{
+    size_t process_id = 0;
+    IO_operation* op = nullptr;
+};
+
+
+#endif //IO_QUEUE_ENTRY_H

--- a/Generic/sys/Storage/StorageDevice.h
+++ b/Generic/sys/Storage/StorageDevice.h
@@ -25,19 +25,33 @@
 #include "CPPMemory.h"
 class ArtFile;
 
-class StorageDevice
-{
+class StorageDevice {
 public:
     virtual ~StorageDevice() = default;
-    virtual i64 read(char* dest, size_t byte_offset, size_t byte_count) = 0;
+
+    virtual i64 read(char *dest, size_t byte_offset, size_t byte_count) = 0;
+
+    virtual i64 async_read(char *dest, size_t byte_offset, size_t byte_count) = 0;
+
+    virtual bool async_done() = 0;
+
+    virtual i64 async_n_read() = 0;
+
     virtual i64 seek(u64 byte_offset, int whence) = 0;
-    virtual i64 write(const char* src, size_t byte_offset, size_t byte_count) = 0;
+
+    virtual i64 write(const char *src, size_t byte_offset, size_t byte_count) = 0;
+
     virtual int mount() =0;
-    virtual ArtFile* find_file(const char* filename) =0;
+
+    virtual ArtFile *find_file(const char *filename) =0;
+
     virtual size_t get_block_size() = 0;
+
     virtual size_t get_block_count() = 0;
+
     virtual size_t get_sector_size() = 0;
-    virtual char* get_name() = 0;
+
+    virtual char *get_name() = 0;
 };
 
 

--- a/Generic/sys/Storage/StorageDevice.h
+++ b/Generic/sys/Storage/StorageDevice.h
@@ -25,25 +25,26 @@
 #include "CPPMemory.h"
 class ArtFile;
 
-class StorageDevice {
+class StorageDevice
+{
 public:
     virtual ~StorageDevice() = default;
 
-    virtual i64 read(char *dest, size_t byte_offset, size_t byte_count) = 0;
+    virtual i64 read(char* dest, size_t byte_offset, size_t byte_count) = 0;
 
-    virtual i64 async_read(char *dest, size_t byte_offset, size_t byte_count) = 0;
+    virtual i64 async_read(char* dest, size_t byte_offset, size_t byte_count) = 0;
 
-    virtual bool async_done() = 0;
+    virtual bool device_busy() = 0;
 
     virtual i64 async_n_read() = 0;
 
     virtual i64 seek(u64 byte_offset, int whence) = 0;
 
-    virtual i64 write(const char *src, size_t byte_offset, size_t byte_count) = 0;
+    virtual i64 write(const char* src, size_t byte_offset, size_t byte_count) = 0;
 
     virtual int mount() =0;
 
-    virtual ArtFile *find_file(const char *filename) =0;
+    virtual ArtFile* find_file(const char* filename) =0;
 
     virtual size_t get_block_size() = 0;
 
@@ -51,7 +52,7 @@ public:
 
     virtual size_t get_sector_size() = 0;
 
-    virtual char *get_name() = 0;
+    virtual char* get_name() = 0;
 };
 
 

--- a/Generic/sys/Terminal/Terminal.h
+++ b/Generic/sys/Terminal/Terminal.h
@@ -144,8 +144,8 @@ public:
 
     i64 write(const char *data, size_t, size_t byte_count) override;
 
-    virtual i64 async_read(char *dest, size_t byte_offset, size_t byte_count) { return -1; }
-    virtual bool async_done() { return true; }
+    virtual i64 async_read(char* dest, size_t byte_offset, size_t byte_count) { return -1; }
+    virtual bool device_busy() { return false; }
     virtual i64 async_n_read() { return -1; }
     i64 seek(u64, int) override { return 0; }
     int mount() override { return 0; }

--- a/Generic/sys/Terminal/Terminal.h
+++ b/Generic/sys/Terminal/Terminal.h
@@ -24,8 +24,7 @@
 #include "colours.h"
 #include "art_string.h"
 
-struct terminal_char_t
-{
+struct terminal_char_t {
     char letter;
     PALETTE_t colour;
 };
@@ -37,104 +36,124 @@ struct terminal_char_t
  * write has many type overloads for default types.
  *
  */
-class Terminal
-{
+class Terminal {
 public:
     // Single instance.
     Terminal(u32 x, u32 y, u32 width, u32 height);
+
     ~Terminal();
-    static Terminal& get();
-    static ArtFile* get_stdout_file();
-    static ArtFile* get_stderr_file();
+
+    static Terminal &get();
+
+    static ArtFile *get_stdout_file();
+
+    static ArtFile *get_stderr_file();
 
     // remove copy functionality
-    Terminal(Terminal const& other) = delete;
-    Terminal& operator=(Terminal const& other) = delete;
+    Terminal(Terminal const &other) = delete;
+
+    Terminal &operator=(Terminal const &other) = delete;
 
     static void newLine();
+
     void userLine();
+
     void setScale(u32 new_scale);
+
     void setRegion(u32 x, u32 y, u32 width, u32 height);
+
     static u32 getScale();
+
     static void clear();
 
     static void stop_drawing();
+
     static void resume_drawing();
 
     // for use with stdout/stderr
-    static u32 user_write(const char* data, u32 count);
-    static u32 user_err(const char* data, u32 count);
+    static u32 user_write(const char *data, u32 count);
+
+    static u32 user_err(const char *data, u32 count);
 
 
     // for normal use/logging.
     static u32 write(bool b);
-    static u32 write(const char* data, size_t len, PALETTE_t colour = COLOR_BASE0); // buffer of fixed len
-    static u32 write(const char* data, PALETTE_t colour = COLOR_BASE0); // buffer without known length also with colour
+
+    static u32 write(const char *data, size_t len, PALETTE_t colour = COLOR_BASE0); // buffer of fixed len
+    static u32 write(const char *data, PALETTE_t colour = COLOR_BASE0); // buffer without known length also with colour
     static u32 write(char c, PALETTE_t colour = COLOR_BASE0); // single char
 
     static void setChar(size_t x, size_t y, char c, PALETTE_t colour);
 
     static void time_stamp();
+
     static void backspace();
+
     static void refresh();
 
 private:
     static void _scroll();
+
     static void _draw_changes();
+
     static void _putChar(terminal_char_t ch, u32 origin_x, u32 origin_y);
-    static void _write_to_screen(const char* data, u32 count, PALETTE_t colour); // or append to queue if not init'ed
-    static void _append_to_queue(const char* data, u32 count, PALETTE_t colour);
-    static void _render_queue(const terminal_char_t* data, size_t len); // used to display data from before init.
+
+    static void _write_to_screen(const char *data, u32 count, PALETTE_t colour); // or append to queue if not init'ed
+    static void _append_to_queue(const char *data, u32 count, PALETTE_t colour);
+
+    static void _render_queue(const terminal_char_t *data, size_t len); // used to display data from before init.
     static void _update_cursor();
 
 public:
-    template <typename int_like>
-        requires is_int_like_v<int_like> && (!is_same_v<int_like, char>) // Any interger like number but not a char or char array.
-    void write(const int_like val, const bool hex = false, PALETTE_t colour = colour_value)
-    {
+    template<typename int_like>
+        requires is_int_like_v<int_like> && (!is_same_v<int_like, char>)
+    // Any interger like number but not a char or char array.
+    void write(const int_like val, const bool hex = false, PALETTE_t colour = colour_value) {
         char out_str[255];
-        if (hex)
-        {
+        if (hex) {
             art_string::hex_from_int(val, out_str, sizeof(val));
-        }
-        else
-        {
+        } else {
             art_string::string_from_int(val, out_str);
         }
         write(out_str, colour);
     }
 
-    template <typename type_t>
-    void log(type_t const& arg1)
-    {
+    template<typename type_t>
+    void log(type_t const &arg1) {
         time_stamp();
         write(arg1);
         newLine();
     }
 
-    template <typename... args_t>
-    void log(args_t&&... args)
-    {
+    template<typename... args_t>
+    void log(args_t &&... args) {
         time_stamp();
         (write(args), ...);
         newLine();
     }
 };
 
-class TermFileWrapper : StorageDevice
-{
+class TermFileWrapper : StorageDevice {
 public:
     explicit TermFileWrapper(bool stderr);
 
 
-    ArtFile* get_file();
-    i64 read(char*, size_t, size_t) override { return 0; }
-    i64 write(const char* data, size_t, size_t byte_count) override;
+    ArtFile *get_file();
 
+    i64 read(char *, size_t, size_t) override { return 0; }
+
+    i64 write(const char *data, size_t, size_t byte_count) override;
+
+    virtual i64 async_read(char *dest, size_t byte_offset, size_t byte_count) { return -1; }
+    virtual bool async_done() { return true; }
+    virtual i64 async_n_read() { return -1; }
     i64 seek(u64, int) override { return 0; }
     int mount() override { return 0; }
-    ArtFile* find_file([[maybe_unused]] const char* filename) override;
-    char* get_name() override;
+
+    ArtFile *find_file([[maybe_unused]] const char *filename) override;
+
+    char *get_name() override;
+
     size_t get_block_size() override { return 1; }
     size_t get_block_count() override { return -1; }
     size_t get_sector_size() override { return 1; }
@@ -145,7 +164,7 @@ private:
     ArtFile file{};
 };
 
-Terminal& get_terminal();
+Terminal &get_terminal();
 
 
 #endif //TERMINAL_H

--- a/Generic/sys/Terminal/Terminal.h
+++ b/Generic/sys/Terminal/Terminal.h
@@ -24,7 +24,8 @@
 #include "colours.h"
 #include "art_string.h"
 
-struct terminal_char_t {
+struct terminal_char_t
+{
     char letter;
     PALETTE_t colour;
 };
@@ -36,23 +37,24 @@ struct terminal_char_t {
  * write has many type overloads for default types.
  *
  */
-class Terminal {
+class Terminal
+{
 public:
     // Single instance.
     Terminal(u32 x, u32 y, u32 width, u32 height);
 
     ~Terminal();
 
-    static Terminal &get();
+    static Terminal& get();
 
-    static ArtFile *get_stdout_file();
+    static ArtFile* get_stdout_file();
 
-    static ArtFile *get_stderr_file();
+    static ArtFile* get_stderr_file();
 
     // remove copy functionality
-    Terminal(Terminal const &other) = delete;
+    Terminal(Terminal const& other) = delete;
 
-    Terminal &operator=(Terminal const &other) = delete;
+    Terminal& operator=(Terminal const& other) = delete;
 
     static void newLine();
 
@@ -71,16 +73,16 @@ public:
     static void resume_drawing();
 
     // for use with stdout/stderr
-    static u32 user_write(const char *data, u32 count);
+    static u32 user_write(const char* data, u32 count);
 
-    static u32 user_err(const char *data, u32 count);
+    static u32 user_err(const char* data, u32 count);
 
 
     // for normal use/logging.
     static u32 write(bool b);
 
-    static u32 write(const char *data, size_t len, PALETTE_t colour = COLOR_BASE0); // buffer of fixed len
-    static u32 write(const char *data, PALETTE_t colour = COLOR_BASE0); // buffer without known length also with colour
+    static u32 write(const char* data, size_t len, PALETTE_t colour = COLOR_BASE0); // buffer of fixed len
+    static u32 write(const char* data, PALETTE_t colour = COLOR_BASE0); // buffer without known length also with colour
     static u32 write(char c, PALETTE_t colour = COLOR_BASE0); // single char
 
     static void setChar(size_t x, size_t y, char c, PALETTE_t colour);
@@ -98,51 +100,58 @@ private:
 
     static void _putChar(terminal_char_t ch, u32 origin_x, u32 origin_y);
 
-    static void _write_to_screen(const char *data, u32 count, PALETTE_t colour); // or append to queue if not init'ed
-    static void _append_to_queue(const char *data, u32 count, PALETTE_t colour);
+    static void _write_to_screen(const char* data, u32 count, PALETTE_t colour); // or append to queue if not init'ed
+    static void _append_to_queue(const char* data, u32 count, PALETTE_t colour);
 
-    static void _render_queue(const terminal_char_t *data, size_t len); // used to display data from before init.
+    static void _render_queue(const terminal_char_t* data, size_t len); // used to display data from before init.
     static void _update_cursor();
 
 public:
-    template<typename int_like>
+    template <typename int_like>
         requires is_int_like_v<int_like> && (!is_same_v<int_like, char>)
     // Any interger like number but not a char or char array.
-    void write(const int_like val, const bool hex = false, PALETTE_t colour = colour_value) {
+    void write(const int_like val, const bool hex = false, PALETTE_t colour = colour_value)
+    {
         char out_str[255];
-        if (hex) {
+        if (hex)
+        {
             art_string::hex_from_int(val, out_str, sizeof(val));
-        } else {
+        }
+        else
+        {
             art_string::string_from_int(val, out_str);
         }
         write(out_str, colour);
     }
 
-    template<typename type_t>
-    void log(type_t const &arg1) {
+    template <typename type_t>
+    void log(type_t const& arg1)
+    {
         time_stamp();
         write(arg1);
         newLine();
     }
 
-    template<typename... args_t>
-    void log(args_t &&... args) {
+    template <typename... args_t>
+    void log(args_t&&... args)
+    {
         time_stamp();
         (write(args), ...);
         newLine();
     }
 };
 
-class TermFileWrapper : StorageDevice {
+class TermFileWrapper : StorageDevice
+{
 public:
     explicit TermFileWrapper(bool stderr);
 
 
-    ArtFile *get_file();
+    ArtFile* get_file();
 
-    i64 read(char *, size_t, size_t) override { return 0; }
+    i64 read(char*, size_t, size_t) override { return 0; }
 
-    i64 write(const char *data, size_t, size_t byte_count) override;
+    i64 write(const char* data, size_t, size_t byte_count) override;
 
     virtual i64 async_read(char* dest, size_t byte_offset, size_t byte_count) { return -1; }
     virtual bool device_busy() { return false; }
@@ -150,9 +159,9 @@ public:
     i64 seek(u64, int) override { return 0; }
     int mount() override { return 0; }
 
-    ArtFile *find_file([[maybe_unused]] const char *filename) override;
+    ArtFile* find_file([[maybe_unused]] const char* filename) override;
 
-    char *get_name() override;
+    char* get_name() override;
 
     size_t get_block_size() override { return 1; }
     size_t get_block_count() override { return -1; }
@@ -164,7 +173,7 @@ private:
     ArtFile file{};
 };
 
-Terminal &get_terminal();
+Terminal& get_terminal();
 
 
 #endif //TERMINAL_H

--- a/Specific/Devices/Storage/IDEStorageContainer.h
+++ b/Specific/Devices/Storage/IDEStorageContainer.h
@@ -46,7 +46,7 @@ struct dma_read_context {
     size_t bytes_read;         // how much we have read so far
     i64 byte_offset;
     size_t lba_offset;
-    bool done;                 // indicates all data transferred
+    bool busy = true; // indicates all data transferred
     // any synchronization primitives like a semaphore or event if needed
 };
 
@@ -62,7 +62,7 @@ public:
     void async_notify();
 
     i64 async_read(char* dest, size_t byte_offset, size_t n_bytes) override;
-    bool async_done() override;
+    bool device_busy() override;
     i64 async_n_read() override;
     i64 read(void* dest, size_t byte_offset, size_t n_bytes);
     i64 read_lba(void* dest, size_t lba_offset, size_t n_bytes);
@@ -109,7 +109,7 @@ private:
     ArtDirectory* root_directory = nullptr;
     volatile bool BM_waiting_for_transfer = false; // todo private member
     i64 stored_buffer_start = -1;
-
+    bool busy = false;
     dma_read_context dma_context = {};
 };
 

--- a/Specific/Devices/Storage/IDEStorageContainer.h
+++ b/Specific/Devices/Storage/IDEStorageContainer.h
@@ -40,8 +40,17 @@ typedef int (*readFunc)();
 typedef int (*seekFunc)();
 typedef int (*writeFunc)();
 
-class IDEStorageContainer : public IDE_notifiable, public StorageDevice
-{
+struct dma_read_context {
+    char* user_buffer;      // where the caller wants the full data
+    size_t total_size;         // total size requested
+    size_t bytes_read;         // how much we have read so far
+    i64 byte_offset;
+    size_t lba_offset;
+    bool done;                 // indicates all data transferred
+    // any synchronization primitives like a semaphore or event if needed
+};
+
+class IDEStorageContainer : public IDE_notifiable, public StorageDevice {
 public:
     IDEStorageContainer(IDE_drive_info_t& drive_info, PCIDevice* pci_dev, BusMasterController* bm_dev, const char* new_name);
     ~IDEStorageContainer() override = default; // TODO: remove PRDT?
@@ -49,6 +58,12 @@ public:
     int mount() override;
 
     i64 read(char* dest, size_t byte_offset, size_t n_bytes) override;
+
+    void async_notify();
+
+    i64 async_read(char* dest, size_t byte_offset, size_t n_bytes) override;
+    bool async_done() override;
+    i64 async_n_read() override;
     i64 read(void* dest, size_t byte_offset, size_t n_bytes);
     i64 read_lba(void* dest, size_t lba_offset, size_t n_bytes);
     i64 seek([[maybe_unused]] u64 offset, [[maybe_unused]] int whence) override { return -NOT_IMPLEMENTED; }
@@ -94,6 +109,8 @@ private:
     ArtDirectory* root_directory = nullptr;
     volatile bool BM_waiting_for_transfer = false; // todo private member
     i64 stored_buffer_start = -1;
+
+    dma_read_context dma_context = {};
 };
 
 #endif //IDE_DEVICE_H

--- a/Specific/x86/CPU/CPUID.cpp
+++ b/Specific/x86/CPU/CPUID.cpp
@@ -125,7 +125,7 @@ cpuid_feature_info_t* cpuid_get_feature_info()
 
 void measure_cpu_freq()
 {
-    constexpr double duration_ms = 1000;
+    constexpr u64 duration_ms = 1000;
     const auto start = TSC_get_ticks();
     PIT_sleep_ms(duration_ms);
     const auto end = TSC_get_ticks();

--- a/Specific/x86/Drivers/Storage/IDEStorageContainer.cpp
+++ b/Specific/x86/Drivers/Storage/IDEStorageContainer.cpp
@@ -20,6 +20,9 @@
 
 #include "IDEStorageContainer.h"
 
+#include <paging.h>
+#include <PagingTableKernel.h>
+
 #include "ATAPIDrive.h"
 #include "ATADrive.h"
 
@@ -36,24 +39,22 @@
 #include "Files.h"
 #include "cmp_int.h"
 
-constexpr size_t region_size = 65536;
+constexpr i64 region_size = 65536;
 #define one_sector_size this->drive_dev->get_drive_info()->sector_size
 #define one_block_size this->drive_dev->get_drive_info()->block_size
 
+#define DMA_LOGS false
 
-IDEStorageContainer::IDEStorageContainer(IDE_drive_info_t& drive_info, PCIDevice* pci_dev, BusMasterController* bm_dev, const char* new_name): name(art_string::strdup(new_name))
-{
+IDEStorageContainer::IDEStorageContainer(IDE_drive_info_t &drive_info, PCIDevice *pci_dev, BusMasterController *bm_dev,
+                                         const char *new_name): name(art_string::strdup(new_name)) {
     LOG("Initializing IDEStorageContainer");
     IDE_add_device(this);
-
+    dma_context.done = true;
     this->pci_dev = pci_dev;
     this->bm_dev = bm_dev;
-    if (drive_info.packet_device)
-    {
+    if (drive_info.packet_device) {
         this->drive_dev = new ATAPIDrive(drive_info);
-    }
-    else
-    {
+    } else {
         this->drive_dev = new ATADrive(drive_info);
     }
     this->drive_dev->populate_data();
@@ -61,12 +62,10 @@ IDEStorageContainer::IDEStorageContainer(IDE_drive_info_t& drive_info, PCIDevice
     // Set PCI cmd bit
     // set BM bit
     // clear BM status
-    if (!(pci_dev->get_command() & 0x4))
-    {
+    if (!(pci_dev->get_command() & 0x4)) {
         LOG("Setting PCI command bit 2 to true.");
         pci_dev->set_command_bit(2, true); // enable busmastering
-        if (!(pci_dev->get_command() & 0x4))
-        {
+        if (!(pci_dev->get_command() & 0x4)) {
             LOG("Error enabling busmastering on PCI device.");
             return;
         }
@@ -75,8 +74,7 @@ IDEStorageContainer::IDEStorageContainer(IDE_drive_info_t& drive_info, PCIDevice
     bm_status.error = 1;
     bm_status.interrupt = 1; //  writing 1 clears the bit
     bm_status = bm_dev->set_status(bm_status);
-    if (bm_status.error == 1 || bm_status.interrupt == 1)
-    {
+    if (bm_status.error == 1 || bm_status.interrupt == 1) {
         LOG("Resetting BM status didn't work.");
         return;
     }
@@ -87,30 +85,31 @@ IDEStorageContainer::IDEStorageContainer(IDE_drive_info_t& drive_info, PCIDevice
 }
 
 // Populates directory tree.
-int IDEStorageContainer::mount()
-{
+int IDEStorageContainer::mount() {
     return populate_file_tree();
 }
 
 // Read from byte offset. Useful for use with files.
-i64 IDEStorageContainer::read(char* dest, const size_t byte_offset, const size_t n_bytes)
-{
+i64 IDEStorageContainer::read(char *dest, const size_t byte_offset, const size_t n_bytes) {
     // LOG("Reading from IDEStorageContainer::read(char*...). start: ", byte_offset, " length: ", n_bytes);
-    i64 n_read = 0; // has to be able to be neg but also up to U32_MAX so use an i64. n_read >0 here due to program flow.
+    i64 n_read = 0;
+    // has to be able to be neg but also up to U32_MAX so use an i64. n_read >0 here due to program flow.
     i64 real_offset = byte_offset; // position within disk in bytes
-    while (n_read < n_bytes)
-    {
+    while (n_read < n_bytes) {
         // Only load new physical region if necessary
-        if (real_offset >= (stored_buffer_start + region_size) || real_offset < stored_buffer_start || stored_buffer_start < 0)
-        {
+        if (real_offset >= (stored_buffer_start + region_size) || real_offset < stored_buffer_start ||
+            stored_buffer_start < 0) {
             // rounds down. First sector containing missing data.
             const size_t start_lba = static_cast<u16>((real_offset) / static_cast<i64>(one_block_size));
             if (const int res = read_into_region_from_lba(start_lba); res < 0) { return res; }
         }
 
-        const size_t offset_in_store = real_offset - stored_buffer_start; // should calculate the offset from physical region start.
-        const i64 available_bytes = MIN(n_bytes - n_read, region_size - offset_in_store); // either all remaining bytes or from first byte to end of region
-        art_string::memcpy(&dest[n_read], &bm_dev->physical_region[offset_in_store], static_cast<size_t>(available_bytes));
+        const size_t offset_in_store = real_offset - stored_buffer_start;
+        // should calculate the offset from physical region start.
+        const i64 available_bytes = MIN(n_bytes - n_read, region_size - offset_in_store);
+        // either all remaining bytes or from first byte to end of region
+        art_string::memcpy(&dest[n_read], &bm_dev->physical_region[offset_in_store],
+                           static_cast<size_t>(available_bytes));
         n_read += available_bytes;
         real_offset = byte_offset + n_read;
     }
@@ -118,39 +117,140 @@ i64 IDEStorageContainer::read(char* dest, const size_t byte_offset, const size_t
     return n_read;
 }
 
-i64 IDEStorageContainer::read(void* dest, const size_t byte_offset, const size_t n_bytes)
-{
-    // LOG("Reading from IDEStorageContainer::read(void*...) start: ", byte_offset, " length: ", n_bytes);
-    return read(static_cast<char*>(dest), byte_offset, n_bytes);
+void IDEStorageContainer::async_notify() {
+    size_t offset_in_store;
+    i64 available_bytes;
+    BM_status_t bm_status = bm_dev->get_status();
+    if (bm_status.IDE_active || BM_waiting_for_transfer) {
+#if ENABLE_SERIAL_LOGGING
+        get_serial().log("Notified but IDE still active?");
+#endif
+        return;
+    }
+    if (bm_status.error) {
+#if ENABLE_SERIAL_LOGGING
+        get_serial().log("DMA error D: ");
+#endif
+        goto done;
+    }
+
+    stop_DMA_read(); // should just reset BM start_stop
+    stored_buffer_start = dma_context.lba_offset * one_sector_size;
+    offset_in_store = dma_context.byte_offset - stored_buffer_start;
+    // should calculate the offset from physical region start.
+
+    available_bytes = MIN(dma_context.total_size - dma_context.bytes_read, region_size - offset_in_store);
+
+    // either all remaining bytes or from first byte to end of region
+    art_string::memcpy(&dma_context.user_buffer[dma_context.bytes_read], &bm_dev->physical_region[offset_in_store],
+                       static_cast<size_t>(available_bytes));
+    dma_context.bytes_read += available_bytes;
+    dma_context.byte_offset += available_bytes;
+
+    // start another read if necessary
+
+    if (dma_context.bytes_read < dma_context.total_size) {
+#if ENABLE_SERIAL_LOGGING and DMA_LOGS
+        get_serial().log("DMA read finished but need more data: ", dma_context.bytes_read, " of ",
+                         dma_context.total_size, " bytes. Available this time: ", available_bytes);
+#endif
+        const size_t start_lba = ((dma_context.byte_offset) / static_cast<i64>(one_block_size)) & 0xffff;
+        dma_context.lba_offset = start_lba;
+        constexpr u16 n_sectors = 32;
+        prep_DMA_read(start_lba, n_sectors); // should set up ATA stuff and then set up BM stuff
+        start_DMA_transfer(); // should just set BM start_stop
+        return;
+    }
+#if ENABLE_SERIAL_LOGGING and DMA_LOGS
+    get_serial().log("DMA read finished: ", dma_context.bytes_read, " of ", dma_context.total_size, " bytes");
+#endif
+done:
+
+    const size_t offset_in_page = (reinterpret_cast<uintptr_t>(dma_context.user_buffer) % page_alignment);
+    kernel_pages().unmap_user_to_kernel(reinterpret_cast<uintptr_t>(dma_context.user_buffer),
+                                        dma_context.total_size + offset_in_page);
+    dma_context.done = true;
 }
 
-i64 IDEStorageContainer::read_lba(void* dest, const size_t lba_offset, const size_t n_bytes)
-{
+i64 IDEStorageContainer::async_read(char *dest, size_t byte_offset, size_t n_bytes) {
+    //  if in store, just write now, and return n_read >0
+    // else return n_read = 0 after starting the read.
+    i64 n_read = 0;
+    if (byte_offset < (stored_buffer_start + region_size) && byte_offset > stored_buffer_start &&
+        stored_buffer_start > 0) {
+        const i64 offset_in_store = byte_offset - stored_buffer_start;
+        // should calculate the offset from physical region start.
+        const i64 available_bytes = MIN(n_bytes - n_read, (region_size - offset_in_store));
+        // either all remaining bytes or from first byte to end of region
+        art_string::memcpy(&dest[n_read], &bm_dev->physical_region[offset_in_store],
+                           static_cast<size_t>(available_bytes));
+        n_read += available_bytes;
+        byte_offset += n_read;
+        if (n_read == n_bytes) {
+            return n_read;
+        };
+    }
+
+    constexpr u16 n_sectors = 32;
+    const size_t start_lba = ((byte_offset) / static_cast<i64>(one_block_size)) & 0xFFFF;
+    size_t offset_in_page = (reinterpret_cast<uintptr_t>(dest) % page_alignment);
+
+    dma_context.bytes_read = n_read;
+    dma_context.done = false;
+    dma_context.byte_offset = byte_offset;
+    dma_context.total_size = n_bytes;
+    dma_context.user_buffer = reinterpret_cast<char *>(kernel_pages().map_user_to_kernel(
+                                                           reinterpret_cast<uintptr_t>(dest),
+                                                           n_bytes + offset_in_page) + offset_in_page);
+    dma_context.lba_offset = start_lba;
+
+#if ENABLE_SERIAL_LOGGING and DMA_LOGS
+    get_serial().log("async reading ", n_bytes, " from ", byte_offset, " i.e. LBA: ", start_lba, ". already read: ",
+                     n_read);
+#endif
+
+    // put data in physical region
+    int ret_val = 0;
+    ret_val = prep_DMA_read(start_lba, n_sectors); // should set up ATA stuff and then set up BM stuff
+    if (ret_val != 0) { return -1; }
+    start_DMA_transfer(); // should just set BM start_stop
+    return 0;
+}
+
+bool IDEStorageContainer::async_done() {
+    return dma_context.done;
+}
+
+i64 IDEStorageContainer::async_n_read() {
+    return dma_context.bytes_read;
+}
+
+i64 IDEStorageContainer::read(void *dest, const size_t byte_offset, const size_t n_bytes) {
+    // LOG("Reading from IDEStorageContainer::read(void*...) start: ", byte_offset, " length: ", n_bytes);
+    return read(static_cast<char *>(dest), byte_offset, n_bytes);
+}
+
+i64 IDEStorageContainer::read_lba(void *dest, const size_t lba_offset, const size_t n_bytes) {
     // LOG("Reading from IDEStorageContainer::read_lba. start: ", lba_offset, " length: ", n_bytes);
     const i64 byte_offset = lba_offset * one_block_size;
-    return read(static_cast<char*>(dest), byte_offset, n_bytes);
+    return read(static_cast<char *>(dest), byte_offset, n_bytes);
 }
 
-size_t IDEStorageContainer::get_block_size()
-{
+size_t IDEStorageContainer::get_block_size() {
     return drive_dev->get_drive_info()->block_size;
 }
 
-size_t IDEStorageContainer::get_block_count()
-{
+size_t IDEStorageContainer::get_block_count() {
     return drive_dev->get_drive_info()->capacity_in_LBA;
 }
 
-size_t IDEStorageContainer::get_sector_size()
-{
+size_t IDEStorageContainer::get_sector_size() {
     return drive_dev->get_drive_info()->sector_size;
 }
 
 
-int IDEStorageContainer::prep_DMA_read(size_t lba_offset, size_t n_sectors)
-{
-    if (const int res = drive_dev->start_DMA_read(lba_offset, n_sectors); res != 0)
-    {
+int IDEStorageContainer::prep_DMA_read(size_t lba_offset, size_t n_sectors) {
+    if (const int res = drive_dev->start_DMA_read(lba_offset, n_sectors); res != 0) {
         LOG("Error telling drive to prep for a DMA read");
         return res;
     }
@@ -160,8 +260,7 @@ int IDEStorageContainer::prep_DMA_read(size_t lba_offset, size_t n_sectors)
     return 0;
 }
 
-void IDEStorageContainer::start_DMA_transfer()
-{
+void IDEStorageContainer::start_DMA_transfer() {
     BM_cmd_t bm_cmd = bm_dev->get_cmd();
     bm_cmd.start_stop = 1;
 
@@ -169,38 +268,36 @@ void IDEStorageContainer::start_DMA_transfer()
     bm_dev->set_cmd(bm_cmd);
 }
 
-int IDEStorageContainer::wait_for_DMA_transfer() const
-{
+int IDEStorageContainer::wait_for_DMA_transfer() const {
     // TODO: This is not working properly when running full speed.
     BM_status_t bm_status = bm_dev->get_status();
-    while (BM_waiting_for_transfer && bm_status.IDE_active && !bm_status.error)
-    {
+    while (BM_waiting_for_transfer && bm_status.IDE_active && !bm_status.error) {
         bm_status = bm_dev->get_status();
     }
-    if (BM_waiting_for_transfer)
-    {
-        get_serial().log("BM transfer complete didn't send interrupt. Ignore if in user space :)");
+    if (BM_waiting_for_transfer) {
+#if ENABLE_SERIAL_LOGGING and DMA_LOGS
+        get_serial().log("BM transfer complete didn't send interrupt. Resetting interrupt bit.");
+#endif
+        bm_status.interrupt = true;
+        bm_status = bm_dev->set_status(bm_status);
         // BM_waiting_for_transfer = false;
         return -DEVICE_ERROR;
     }
     return 0;
 }
 
-int IDEStorageContainer::stop_DMA_read()
-{
+int IDEStorageContainer::stop_DMA_read() {
     BM_cmd_t bm_cmd = bm_dev->get_cmd();
     bm_cmd.start_stop = 0;
-    bm_dev->set_cmd(bm_cmd);
-    if (bm_dev->get_status().error)
-    {
+    bm_cmd = bm_dev->set_cmd(bm_cmd);
+    if (bm_dev->get_status().error) {
         return -DEVICE_ERROR;
     }
     return 0;
 }
 
 
-int IDEStorageContainer::read_into_region_from_lba(size_t lba_offset)
-{
+int IDEStorageContainer::read_into_region_from_lba(size_t lba_offset) {
     // TODO: This should always be called to read 64K at a time.
 
     // trim oversize reads
@@ -215,14 +312,18 @@ int IDEStorageContainer::read_into_region_from_lba(size_t lba_offset)
     //TODO: This needs to have a mutex or something! We need this to be able to read inside a disable interrupts.
     // if (ret_val != 0) { return ret_val; }
     ret_val = stop_DMA_read(); // should just reset BM start_stop
-    if (ret_val != 0) { return ret_val; }
+    if (ret_val != 0) {
+#if ENABLE_SERIAL_LOGGING
+        get_serial().log("stop dma read has error?");
+#endif
+        return ret_val;
+    }
     stored_buffer_start = lba_offset * one_sector_size;
     return ret_val;
 }
 
 // Called by interrupt handler.
-void IDEStorageContainer::notify()
-{
+void IDEStorageContainer::notify() {
     // LOG("IDEStorageContainer notified.");
     // Should just check if this controller/drive_dev was to be handled or not.
     if (!(BM_waiting_for_transfer || drive_dev->is_waiting_for_transfer())) return;
@@ -230,84 +331,74 @@ void IDEStorageContainer::notify()
     BM_status_t bm_status = bm_dev->get_status();
     const ATA_status_t ata_status = drive_dev->get_status();
 #ifndef NDEBUG
-    switch (const u8 ata_interrupt_reason = drive_dev->get_interrupt_reason(); ata_interrupt_reason)
-    {
-    case 0:
-        {
+    switch (const u8 ata_interrupt_reason = drive_dev->get_interrupt_reason(); ata_interrupt_reason) {
+        case 0: {
             break;
         }
-    case 1:
-        {
+        case 1: {
             LOG("Command/Data bit set");
             break;
         }
-    case 2:
-        {
+        case 2: {
             LOG("IO bit set");
             break;
         }
-    default:
-        {
+        default: {
             break;
         }
     }
-    if (ata_status.error)
-    {
+    if (ata_status.error) {
         // LOG("ATA device errored");
         drive_dev->set_waiting_for_transfer(false);
     }
 #endif
-    if (ata_status.data_request)
-    {
+    if (ata_status.data_request) {
         // LOG("ATA sent command");
         drive_dev->set_waiting_for_transfer(false);
-    }
-    else
-    {
+    } else {
         // LOG("ATA probably didn't send command");
         BM_waiting_for_transfer = false;
     }
 
-    if (bm_status.interrupt)
-    {
+    if (bm_status.interrupt) {
         // LOG("BM interrupt raised.");
+        if (!dma_context.done) {
+            async_notify();
+        }
         bm_status.interrupt = true;
         bm_status = bm_dev->set_status(bm_status);
     }
 }
 
-ArtFile* IDEStorageContainer::find_file(const char* filename)
-{
+ArtFile *IDEStorageContainer::find_file(const char *filename) {
     return root_directory->search_recurse(filename);
 }
 
 /* convert an iso_directory_record_header into DirectoryData for use with ArtDirectory entries.*/
-DirectoryData IDEStorageContainer::dir_record_to_directory(const iso_directory_record_header& info, char*& name)
-{
+DirectoryData IDEStorageContainer::dir_record_to_directory(const iso_directory_record_header &info, char *&name) {
     return
-        DirectoryData{
-            this,
-            info.extent_loc_LE,
-            info.data_length_LE,
-            tm{
-                info.datetime.second,
-                info.datetime.minute,
-                info.datetime.hour,
-                info.datetime.monthday,
-                info.datetime.month,
-                info.datetime.years_since_1900 + 1900,
-                0,
-                0,
-                0
-            },
-            1,
-            name
-        };
+            DirectoryData{
+                this,
+                info.extent_loc_LE,
+                info.data_length_LE,
+                tm{
+                    info.datetime.second,
+                    info.datetime.minute,
+                    info.datetime.hour,
+                    info.datetime.monthday,
+                    info.datetime.month,
+                    info.datetime.years_since_1900 + 1900,
+                    0,
+                    0,
+                    0
+                },
+                1,
+                name
+            };
 }
 
 /* convert an iso_directory_record_header into FileData for use with ArtDirectory entries.*/
-FileData IDEStorageContainer::dir_record_to_file(const iso_directory_record_header& info, char*& name)
-{
+FileData IDEStorageContainer::dir_record_to_file(const iso_directory_record_header &info, char *&name) {
     return FileData{
         this,
         info.extent_loc_LE,
@@ -329,8 +420,7 @@ FileData IDEStorageContainer::dir_record_to_file(const iso_directory_record_head
 }
 
 /* Loads the start of the volume descriptor from a CD ROM. Returns the iso_primary_volume_descriptor_t */
-iso_primary_volume_descriptor_t IDEStorageContainer::get_primary_volume_descriptor()
-{
+iso_primary_volume_descriptor_t IDEStorageContainer::get_primary_volume_descriptor() {
     iso_primary_volume_descriptor_t vd{};
     constexpr size_t buf_size = sizeof(iso_primary_volume_descriptor_t);
     constexpr u32 data_start_lba = 16; // in LBA#
@@ -343,8 +433,7 @@ iso_primary_volume_descriptor_t IDEStorageContainer::get_primary_volume_descript
  * locate the root dir in the ISO 9660 directory listing.
  * Returns the iso_path_table_entry_header for use with directory populating.
  */
-iso_path_table_entry_header IDEStorageContainer::get_path_table_root_dir()
-{
+iso_path_table_entry_header IDEStorageContainer::get_path_table_root_dir() {
     // Load primary volume descriptor
     const iso_primary_volume_descriptor_t volume_descriptor = get_primary_volume_descriptor();
 
@@ -353,99 +442,86 @@ iso_path_table_entry_header IDEStorageContainer::get_path_table_root_dir()
     read_lba(&path_table_data, volume_descriptor.path_l_table_loc_lba, volume_descriptor.path_table_size_LE);
 
     // get first dir entry. Ignore name because it is blank anyway.
-    return *reinterpret_cast<iso_path_table_entry_header*>(path_table_data);
+    return *reinterpret_cast<iso_path_table_entry_header *>(path_table_data);
 }
 
 /* Given the lba
  *
  */
-size_t IDEStorageContainer::get_dir_entry_size(ArtDirectory*& target_dir)
-{
+size_t IDEStorageContainer::get_dir_entry_size(ArtDirectory *&target_dir) {
     char first_sector_data[this->drive_dev->get_drive_info()->sector_size];
     read_lba(&first_sector_data, target_dir->get_lba(), one_sector_size);
-    size_t ret = *reinterpret_cast<u64*>(&first_sector_data[10]);
+    size_t ret = *reinterpret_cast<u64 *>(&first_sector_data[10]);
     return ret;
 }
 
-u8 IDEStorageContainer::populate_filename(char* sub_data, const u8 expected_name_length, const size_t ext_length, char*& filename) const
-{
+u8 IDEStorageContainer::populate_filename(char *sub_data, const u8 expected_name_length, const size_t ext_length,
+                                          char *&filename) const {
     filename = art_string::strndup(sub_data, expected_name_length);
-    if (art_string::strncmp(filename, "", expected_name_length) == 0 || art_string::strncmp(filename, "\1", expected_name_length) == 0)
-    {
+    if (art_string::strncmp(filename, "", expected_name_length) == 0 || art_string::strncmp(
+            filename, "\1", expected_name_length) == 0) {
         art_free(filename);
         return 0;
     }
     size_t extension_pos = 0;
-    while (extension_pos < ext_length)
-    {
-        if (sub_data[expected_name_length + extension_pos] == 0)
-        {
+    while (extension_pos < ext_length) {
+        if (sub_data[expected_name_length + extension_pos] == 0) {
             extension_pos++;
             continue;
         }
-        auto [tag, len] = *reinterpret_cast<file_id_ext_header*>(&sub_data[expected_name_length + extension_pos]);
-        if (art_string::strncmp(tag, "NM", 2) == 0)
-        {
+        auto [tag, len] = *reinterpret_cast<file_id_ext_header *>(&sub_data[expected_name_length + extension_pos]);
+        if (art_string::strncmp(tag, "NM", 2) == 0) {
             art_free(filename);
             filename = art_string::strndup(&sub_data[expected_name_length + extension_pos + 5], len - 5);
             return len - 4;
         }
-        if (len > 0)
-        {
+        if (len > 0) {
             extension_pos += len;
-        }
-        else
-        {
+        } else {
             return expected_name_length;
         }
     }
     return expected_name_length;
 }
 
-int IDEStorageContainer::populate_directory(ArtDirectory*& target_dir)
-{
+int IDEStorageContainer::populate_directory(ArtDirectory *&target_dir) {
     size_t buffer_size = get_dir_entry_size(target_dir);
     char full_data[buffer_size];
     read_lba(&full_data, target_dir->get_lba(), buffer_size);
     size_t offset = 0;
-    while (offset < buffer_size)
-    {
+    while (offset < buffer_size) {
         const size_t start_offset = offset;
         /*
          *  If there are more entries after this one but which start on the next sector, the sector will be padded with zeros.
          *  If the first value (record length) is zero, we skip to the first byte of the next sector. If this is out of bounds,
          *  the loop ends, otherwise the reading continues.
          */
-        if (full_data[offset] == 0)
-        {
-            offset = offset + (one_sector_size - (offset % one_sector_size)); // skips remaining bytes to start of next sector
+        if (full_data[offset] == 0) {
+            offset = offset + (one_sector_size - (offset % one_sector_size));
+            // skips remaining bytes to start of next sector
             continue;
         }
-        auto dir_record = *reinterpret_cast<iso_directory_record_header*>(&full_data[offset]);
+        auto dir_record = *reinterpret_cast<iso_directory_record_header *>(&full_data[offset]);
 
 
         offset += sizeof(iso_directory_record_header); // skip header to names
-        char* filename;
+        char *filename;
         dir_record.file_name_length = populate_filename(
             &full_data[offset],
             dir_record.file_name_length,
             dir_record.record_length - sizeof(iso_directory_record_header),
             filename
         );
-        if (dir_record.file_name_length == 0)
-        {
+        if (dir_record.file_name_length == 0) {
             offset = start_offset + dir_record.record_length;
             continue;
         } // is either current or parent dir's entry or broken.;
         [[maybe_unused]] u32 data_len = dir_record.data_length_LE;
         u8 flags = dir_record.flags;
 
-        if (flags & 0x2)
-        {
+        if (flags & 0x2) {
             target_dir->add_subdir(target_dir, dir_record_to_directory(dir_record, filename));
-        }
-        else
-        {
+        } else {
             target_dir->add_file(dir_record_to_file(dir_record, filename));
         }
 
@@ -458,29 +534,26 @@ int IDEStorageContainer::populate_directory(ArtDirectory*& target_dir)
     return 0;
 }
 
-ArtDirectory* IDEStorageContainer::make_root_directory(const iso_path_table_entry_header& p_t_r)
-{
+ArtDirectory *IDEStorageContainer::make_root_directory(const iso_path_table_entry_header &p_t_r) {
     char first_sector_data[one_sector_size];
     read_lba(&first_sector_data, p_t_r.extent_loc, one_sector_size);
-    char* root_dir_name = art_string::strdup("/");
-    const auto dir_record = *reinterpret_cast<iso_directory_record_header*>(&first_sector_data[0]);
+    char *root_dir_name = art_string::strdup("/");
+    const auto dir_record = *reinterpret_cast<iso_directory_record_header *>(&first_sector_data[0]);
     return new ArtDirectory{
         nullptr,
         dir_record_to_directory(dir_record, root_dir_name),
     };
 }
 
-int IDEStorageContainer::populate_directory_recursive(ArtDirectory* target_dir)
-{
+int IDEStorageContainer::populate_directory_recursive(ArtDirectory *target_dir) {
     populate_directory(target_dir);
     auto device = this;
-    target_dir->get_dirs()->iterate([device](ArtDirectory* dir) { device->populate_directory_recursive(dir); });
+    target_dir->get_dirs()->iterate([device](ArtDirectory *dir) { device->populate_directory_recursive(dir); });
     // todo: Error handling.
     return 0;
 }
 
-int IDEStorageContainer::populate_file_tree()
-{
+int IDEStorageContainer::populate_file_tree() {
     // todo refactor into void function?
     LOG("Constructing CD ROM directory tree");
     const auto path_table_root = get_path_table_root_dir();

--- a/Specific/x86/Drivers/Storage/IDEStorageContainer.cpp
+++ b/Specific/x86/Drivers/Storage/IDEStorageContainer.cpp
@@ -200,15 +200,12 @@ i64 IDEStorageContainer::async_read(char *dest, size_t byte_offset, size_t n_byt
 
     constexpr u16 n_sectors = 32;
     const size_t start_lba = ((byte_offset) / static_cast<i64>(one_block_size)) & 0xFFFF;
-    size_t offset_in_page = (reinterpret_cast<uintptr_t>(dest) % page_alignment);
 
     dma_context.bytes_read = n_read;
     dma_context.busy = true;
     dma_context.byte_offset = byte_offset;
     dma_context.total_size = n_bytes;
-    dma_context.user_buffer = reinterpret_cast<char *>(kernel_pages().map_user_to_kernel(
-                                                           reinterpret_cast<uintptr_t>(dest),
-                                                           n_bytes + offset_in_page) + offset_in_page);
+    dma_context.user_buffer = dest;
     dma_context.lba_offset = start_lba;
 
 #if ENABLE_SERIAL_LOGGING and DMA_LOGS

--- a/Specific/x86/Memory/PagingTableKernel.cpp
+++ b/Specific/x86/Memory/PagingTableKernel.cpp
@@ -23,6 +23,8 @@
 #include <art_string.h>
 #include <cmp_int.h>
 #include <PagingTable.h>
+#include <PagingTableUser.h>
+#include <Scheduler.h>
 
 
 DenseBooleanArray<u64> page_available_virtual_bitmap;
@@ -39,18 +41,18 @@ extern page_table boot_page_tables[];
 // }
 
 
-void PagingTableKernel::assign_page_directory_entry(const size_t dir_idx, const bool writable, const bool user)
-{
+void PagingTableKernel::assign_page_directory_entry(const size_t dir_idx, const bool writable, const bool user) {
     page_directory_4kb_t dir_entry{};
     dir_entry.present = true;
-    dir_entry.page_table_entry_address = reinterpret_cast<uintptr_t>(&boot_page_tables[dir_idx]) - 0xc0000000 >> base_address_shift; // might be wrong.
+    dir_entry.page_table_entry_address = reinterpret_cast<uintptr_t>(&boot_page_tables[dir_idx]) - 0xc0000000 >>
+                                         base_address_shift; // might be wrong.
     dir_entry.rw = writable;
     dir_entry.user_access = user;
     boot_page_directory[dir_idx] = dir_entry;
 }
 
-void PagingTableKernel::assign_page_table_entry(const uintptr_t physical_addr, const virtual_address_t v_addr, const bool writable, const bool user)
-{
+void PagingTableKernel::assign_page_table_entry(const uintptr_t physical_addr, const virtual_address_t v_addr,
+                                                const bool writable, const bool user) {
     // TODO: This should definitely be a method of the class.
     page_table_entry_t tab_entry;
     tab_entry.present = true;
@@ -63,12 +65,10 @@ void PagingTableKernel::assign_page_table_entry(const uintptr_t physical_addr, c
 }
 
 
-int PagingTableKernel::unassign_page_table_entries(const size_t start_idx, const size_t n_pages)
-{
+int PagingTableKernel::unassign_page_table_entries(const size_t start_idx, const size_t n_pages) {
     // TODO: mark empty dicts as not present?
-    for (size_t i = start_idx; i < start_idx + n_pages; i++)
-    {
-        auto* tab_entry = &boot_page_tables[i / 1024].table[i % 1024];
+    for (size_t i = start_idx; i < start_idx + n_pages; i++) {
+        auto *tab_entry = &boot_page_tables[i / 1024].table[i % 1024];
         if (!tab_entry->present)return -1;
 
         const size_t phys_idx = tab_entry->physical_address;
@@ -81,78 +81,116 @@ int PagingTableKernel::unassign_page_table_entries(const size_t start_idx, const
     return 0;
 }
 
+uintptr_t PagingTableKernel::map_user_to_kernel(const uintptr_t user_vaddr, const i64 length) {
+    const size_t n_pages = (length + page_alignment - 1) >> base_address_shift;
+    PagingTableUser &user_tables = Scheduler::get().getCurrentPagingTable();
+    const uintptr_t k_v_addr = get_next_virtual_chunk(0, n_pages);
+    uintptr_t working_user_v_addr = user_vaddr;
+    uintptr_t working_k_v_addr = k_v_addr;
+    for (int i = 0; i < n_pages; i++) {
+        const uintptr_t phys = user_tables.get_phys_from_virtual(working_user_v_addr);
+        direct_map(phys, working_k_v_addr, true, false);
+        working_user_v_addr += page_alignment;
+        working_k_v_addr += page_alignment;
+    }
+    reserve_kernel_v_addr_space(reinterpret_cast<void *>(k_v_addr),
+                                reinterpret_cast<void *>(k_v_addr + (n_pages * page_alignment)));
+    return k_v_addr;
+}
+
+void PagingTableKernel::unmap_user_to_kernel(uintptr_t kernel_vaddr, i64 length) {
+    uintptr_t working_addr = kernel_vaddr;
+    const size_t n_pages = (length + page_alignment - 1) >> base_address_shift;
+    for (size_t i = 0; i < n_pages; i++) {
+        const auto v = virtual_address_t{working_addr};
+        page_table_entry_t &table = boot_page_tables[v.page_directory_index].table[v.page_table_index];
+        table = {};
+        working_addr += page_alignment;
+    }
+    unreserve_kernel_v_addr_space(reinterpret_cast<void *>(kernel_vaddr),
+                                  reinterpret_cast<void *>(kernel_vaddr + (n_pages * page_alignment)));
+}
+
+
+void PagingTableKernel::direct_map(const uintptr_t physical_address, const uintptr_t virt_addr, const bool writable,
+                                   const bool user) {
+    const auto v = virtual_address_t{virt_addr};
+    boot_page_directory[v.page_directory_index].present = true;
+    boot_page_directory[v.page_directory_index].rw = true;
+    page_table_entry_t &table = boot_page_tables[v.page_directory_index].table[v.page_table_index];
+    table.present = true;
+    table.physical_address = physical_address >> base_address_shift;
+    table.rw = writable;
+    table.user_access = user;
+}
 
 /** Marks a section of the vbitmap as used
  */
-void PagingTableKernel::reserve_kernel_v_addr_space(void* start, void* end)
-{
+void PagingTableKernel::reserve_kernel_v_addr_space(void *start, void *end) {
     auto start_idx = reinterpret_cast<uintptr_t>(start) >> base_address_shift;
     auto end_idx = (reinterpret_cast<uintptr_t>(end) >> base_address_shift);
     page_available_virtual_bitmap.set_range(start_idx, end_idx, false);
 }
 
+void PagingTableKernel::unreserve_kernel_v_addr_space(void *start, void *end) {
+    auto start_idx = reinterpret_cast<uintptr_t>(start) >> base_address_shift;
+    auto end_idx = (reinterpret_cast<uintptr_t>(end) >> base_address_shift);
+    page_available_virtual_bitmap.set_range(start_idx, end_idx, true);
+}
 
-PagingTableKernel::PagingTableKernel()
-{
+
+PagingTableKernel::PagingTableKernel() {
     page_available_virtual_bitmap.init(paging_virt_bitmap_array, max_n_pages, true);
     // paging_directory = &boot_page_directory;
     // paging_tables = &boot_page_tables;
 }
 
-void* PagingTableKernel::mmap(const uintptr_t addr, const size_t length, int prot, int flags, int fd, size_t offset)
-{
+void *PagingTableKernel::mmap(const uintptr_t addr, const size_t length, int prot, int flags, int fd, size_t offset) {
     const size_t first_page = addr >> base_address_shift;
     const size_t num_pages = (length + page_alignment - 1) >> base_address_shift;
 
     const virtual_address_t ret_addr = {get_next_virtual_chunk(first_page, num_pages)};
     if (ret_addr.raw == 0) return nullptr;
     virtual_address_t working_addr = ret_addr;
-    for (size_t i = 0; i < num_pages; i++)
-    {
-        if (!dir_entry_present(working_addr.page_directory_index))
-        {
+    for (size_t i = 0; i < num_pages; i++) {
+        if (!dir_entry_present(working_addr.page_directory_index)) {
             // TODO: handle flag ints as bools here
             assign_page_directory_entry(working_addr.page_directory_index, prot & PAGING_WRITABLE, flags & PAGING_USER);
         }
 
 
-        if (const auto phys_addr = page_get_next_phys_addr(); phys_addr != 0)
-        {
+        if (const auto phys_addr = page_get_next_phys_addr(); phys_addr != 0) {
             assign_page_table_entry(
                 phys_addr,
                 working_addr,
                 true,
                 false
             );
-        }
-        else
-        {
+        } else {
             return nullptr;
         }
 
         working_addr.raw += page_alignment;
     }
 
-    const auto p = reinterpret_cast<void*>(ret_addr.raw);
+    const auto p = reinterpret_cast<void *>(ret_addr.raw);
     art_string::memset(p, 0, length);
     return p;
 }
 
 
-void PagingTableKernel::identity_map(uintptr_t phys_addr, const size_t size, const bool writable, const bool user)
-{
+void PagingTableKernel::identity_map(uintptr_t phys_addr, const size_t size, const bool writable, const bool user) {
     virtual_address_t virtual_address = {.raw = phys_addr};
 
     const size_t num_pages = (size + page_alignment - 1) >> base_address_shift;
-    for (size_t i = 0; i < num_pages; i++)
-    {
+    for (size_t i = 0; i < num_pages; i++) {
         // Every 1024 table entries requires a new dir entry.
         // if (!boot_page_tables[virtual_address.page_directory_index].table[virtual_address.page_table_index].present)
         // {
         assign_page_table_entry(phys_addr, virtual_address, writable, user);
         // }
-        if (!boot_page_directory[virtual_address.page_directory_index].present || virtual_address.page_table_index == 0)
-        {
+        if (!boot_page_directory[virtual_address.page_directory_index].present || virtual_address.page_table_index ==
+            0) {
             assign_page_directory_entry(virtual_address.page_directory_index, writable, user);
         }
 
@@ -164,55 +202,48 @@ void PagingTableKernel::identity_map(uintptr_t phys_addr, const size_t size, con
 }
 
 // TODO: More checks such as "you don't own this memory"
-int PagingTableKernel::munmap(void* addr, const size_t length_bytes)
-{
+int PagingTableKernel::munmap(void *addr, const size_t length_bytes) {
     return unassign_page_table_entries(
         reinterpret_cast<uintptr_t>(addr) >> base_address_shift,
         (length_bytes + page_alignment - 1) >> base_address_shift); // this rounds up
 }
 
-uintptr_t PagingTableKernel::get_phys_addr_of_page_dir()
-{
+uintptr_t PagingTableKernel::get_phys_addr_of_page_dir() {
     return get_phys_from_virtual(reinterpret_cast<uintptr_t>(&boot_page_directory) - 0xc0000000) << base_address_shift;
 }
 
-uintptr_t PagingTableKernel::get_next_virtual_chunk(size_t idx, const size_t n_pages)
-{
+uintptr_t PagingTableKernel::get_next_virtual_chunk(size_t idx, const size_t n_pages) {
     const uintptr_t min_idx = MAX(idx, 768*1024);
     idx = page_available_virtual_bitmap.get_next_trues(min_idx, n_pages);
     if (idx == DBA_ERR_IDX) return 0;
     return idx << base_address_shift;
 }
 
-uintptr_t PagingTableKernel::get_next_virtual_addr(const uintptr_t start_addr)
-{
+uintptr_t PagingTableKernel::get_next_virtual_addr(const uintptr_t start_addr) {
     const uintptr_t min_addr = MAX(start_addr, 0xc0000000);
     const size_t idx = page_available_virtual_bitmap.get_next_true(min_addr >> base_address_shift);
     if (idx == DBA_ERR_IDX) return 0;
     return idx << base_address_shift;
 }
 
-bool PagingTableKernel::dir_entry_present(const size_t idx)
-{
+bool PagingTableKernel::dir_entry_present(const size_t idx) {
     return boot_page_directory[idx].present;
 }
 
 
-uintptr_t PagingTableKernel::get_phys_from_virtual(const uintptr_t v_addr)
-{
+uintptr_t PagingTableKernel::get_phys_from_virtual(const uintptr_t v_addr) {
     const virtual_address_t lookup = {v_addr};
-    if (const auto entry = boot_page_tables[lookup.page_directory_index].table[lookup.page_table_index]; entry.present)
-    {
+    if (const auto entry = boot_page_tables[lookup.page_directory_index].table[lookup.page_table_index]; entry.
+        present) {
         return entry.physical_address;
     }
     return 0;
 }
 
-page_table_entry_t PagingTableKernel::check_vmap_contents(const uintptr_t v_addr)
-{
+page_table_entry_t PagingTableKernel::check_vmap_contents(const uintptr_t v_addr) {
     const virtual_address_t lookup = {v_addr};
-    if (const auto entry = boot_page_tables[lookup.page_directory_index].table[lookup.page_table_index]; entry.present)
-    {
+    if (const auto entry = boot_page_tables[lookup.page_directory_index].table[lookup.page_table_index]; entry.
+        present) {
         return entry;
     }
     return page_table_entry_t{};

--- a/Specific/x86/Memory/PagingTableKernel.h
+++ b/Specific/x86/Memory/PagingTableKernel.h
@@ -27,27 +27,45 @@
 #include "paging.h"
 
 
-class PagingTableKernel : public PagingTable
-{
+class PagingTableKernel : public PagingTable {
 public:
     PagingTableKernel();
 
     // void late_init();
 
-    void* mmap(uintptr_t addr, size_t length, int prot, int flags, int fd, size_t offset) override;
+    void *mmap(uintptr_t addr, size_t length, int prot, int flags, int fd, size_t offset) override;
+
     void identity_map(uintptr_t phys_addr, size_t size, bool writable, bool user);
-    int munmap(void* addr, size_t length_bytes) override;
+
+    int munmap(void *addr, size_t length_bytes) override;
+
     uintptr_t get_phys_addr_of_page_dir() override;
+
     uintptr_t get_next_virtual_chunk(size_t idx, size_t n_pages);
+
     uintptr_t get_next_virtual_addr(uintptr_t start_addr);
+
     bool dir_entry_present(size_t idx) override;
+
     uintptr_t get_phys_from_virtual(uintptr_t v_addr) override;
+
     page_table_entry_t check_vmap_contents(uintptr_t v_addr) override;
+
     void assign_page_table_entry(uintptr_t physical_addr, virtual_address_t v_addr, bool writable, bool user);
+
     void assign_page_directory_entry(size_t dir_idx, bool writable, bool user);
+
     int unassign_page_table_entries(size_t start_idx, size_t n_pages) override;
-    void direct_map(uintptr_t sector_start, size_t sector_size, u8 permissions);
-    void reserve_kernel_v_addr_space(void* start, void* end);
+
+    uintptr_t map_user_to_kernel(uintptr_t user_vaddr, i64 length);
+
+    void unmap_user_to_kernel(uintptr_t kernel_vaddr, i64 length);
+
+    void direct_map(uintptr_t physical_address, uintptr_t virt_addr, bool writable, bool user);
+
+    void reserve_kernel_v_addr_space(void *start, void *end);
+
+    void unreserve_kernel_v_addr_space(void *start, void *end);
 
 private:
     DenseBooleanArray<u64> page_available_virtual_bitmap;

--- a/Specific/x86/Memory/PagingTableUser.cpp
+++ b/Specific/x86/Memory/PagingTableUser.cpp
@@ -71,11 +71,8 @@ PagingTableUser::~PagingTableUser() {
 uintptr_t PagingTableUser::get_phys_from_virtual(uintptr_t v_addr) {
     const virtual_address_t lookup = {v_addr};
 
-    auto [table] = *reinterpret_cast<page_table *>(
-        paging_directory[lookup.page_directory_index].page_table_entry_address << base_address_shift);
-
-    if (const auto entry = table[lookup.page_table_index]; entry.present) {
-        return entry.physical_address;
+    if (const auto entry = paging_table[lookup.page_directory_index].table[lookup.page_table_index]; entry.present) {
+        return entry.physical_address << base_address_shift;
     }
     return 0;
 }

--- a/Specific/x86/Memory/PagingTableUser.h
+++ b/Specific/x86/Memory/PagingTableUser.h
@@ -42,7 +42,6 @@ public:
     page_table* append_page_table(bool writable, bool user);
     void assign_page_table_entries(uintptr_t physical_addr, uintptr_t virt_addr, bool writable, bool user);
     int unassign_page_table_entries(size_t start_idx, size_t n_pages) override;
-    int known_mapping(uintptr_t start_address, uintptr_t end_address);
 
 private:
     page_directory_4kb_t* paging_directory = nullptr;

--- a/Specific/x86/Memory/paging.cpp
+++ b/Specific/x86/Memory/paging.cpp
@@ -184,7 +184,7 @@ void *kmmap(uintptr_t addr, size_t length, int prot, int flags, int fd, size_t o
 }
 
 void *user_mmap(uintptr_t addr, size_t length, int prot, int flags, int fd, size_t offset) {
-    return Scheduler::get().getCurrentPagingTable()->mmap(addr, length, prot, flags, fd, offset);
+    return Scheduler::get().getCurrentPagingTable().mmap(addr, length, prot, flags, fd, offset);
 }
 
 uintptr_t kget_mapping_target(void *v_addr) {
@@ -196,7 +196,7 @@ int kmunmap(void *addr, const size_t length_bytes) {
 }
 
 int user_munmap(void *addr, const size_t length_bytes) {
-    return Scheduler::get().getCurrentPagingTable()->munmap(addr, length_bytes);
+    return Scheduler::get().getCurrentPagingTable().munmap(addr, length_bytes);
 }
 
 void paging_identity_map(const uintptr_t phys_addr, const size_t size, const bool writable, const bool user) {

--- a/Specific/x86/syscall.cpp
+++ b/Specific/x86/syscall.cpp
@@ -41,51 +41,62 @@ struct _PDCLIB_file_t;
 
 // u64 clock_rate = 0;
 
-void kwrite_standard([[maybe_unused]] const char *buffer, [[maybe_unused]] unsigned long len) {
+void kwrite_standard([[maybe_unused]] const char* buffer, [[maybe_unused]] unsigned long len)
+{
     WRITE(buffer, len);
 }
 
-void kwrite_error([[maybe_unused]] const char *buffer, [[maybe_unused]] unsigned long len) {
+void kwrite_error([[maybe_unused]] const char* buffer, [[maybe_unused]] unsigned long len)
+{
     // // todo: implement the propagation of colour so that this can be overridden to use red for errors or something.
 
     WRITE(buffer, len);
 }
 
-int kget_time(tm *mytm) {
+int kget_time(tm* mytm)
+{
     return RTC::get().getTime(mytm);
 }
 
 
-time_t kget_epoch_time() {
+time_t kget_epoch_time()
+{
     return RTC::get().epochTime();
 }
 
 extern "C"
-void _kexit(size_t target_pid) {
+void _kexit(size_t target_pid)
+{
     Scheduler::kill(target_pid);
 }
 
-u64 kget_clock_rate_hz() {
+u64 kget_clock_rate_hz()
+{
     return cpuid_get_TSC_frequency();
 }
 
-u64 kget_current_clock() {
+u64 kget_current_clock()
+{
     return TSC_get_ticks();
 }
 
-u64 kget_tick_s() {
+u64 kget_tick_s()
+{
     return TSC_get_ticks() / cpuid_get_TSC_frequency();
 }
 
-u64 kget_tick_ms() {
+u64 kget_tick_ms()
+{
     return (TSC_get_ticks() * 1000) / cpuid_get_TSC_frequency();
 }
 
-u64 kget_tick_us() {
+u64 kget_tick_us()
+{
     return (static_cast<uint64_t>(TSC_get_ticks()) * 1000000) / cpuid_get_TSC_frequency();
 }
 
-u64 kget_tick_ns() {
+u64 kget_tick_ns()
+{
     return (static_cast<uint64_t>(TSC_get_ticks()) * 1000000000) / cpuid_get_TSC_frequency();
 }
 
@@ -98,178 +109,170 @@ u64 kget_tick_ns() {
 //     PIT_sleep_ms(ms);
 // }
 
-void ksleep_ms(cpu_registers_t *r) {
+void ksleep_ms(cpu_registers_t* r)
+{
     Scheduler::sleep_ms(r);
     // PIT_sleep_ms(ms);
 }
 
-void ksleep_ns(const u32 ns) {
+void ksleep_ns(const u32 ns)
+{
     const u32 start = kget_tick_ns();
-    while (kget_tick_ns() - start < ns) {
+    while (kget_tick_ns() - start < ns)
+    {
     }
 }
 
-void ksleep_us(const u32 us) {
+void ksleep_us(const u32 us)
+{
     const u32 start = kget_tick_us();
-    while (kget_tick_us() - start < us) {
+    while (kget_tick_us() - start < us)
+    {
     }
 }
 
 
-void kpause_exec(const u32 ms) {
+void kpause_exec(const u32 ms)
+{
     PIT_sleep_ms(ms);
 }
 
-bool kprobe_pending_events() {
+bool kprobe_pending_events()
+{
     return Scheduler::getCurrentProcessEventQueue()->pendingEvents();
 }
 
-event_t kget_next_event() {
+event_t kget_next_event()
+{
     // TODO: this should only get events associated with the correct event queue.
     // There should not be a generic system event queue but instead there should be one associated with each processes
     return Scheduler::getCurrentProcessEventQueue()->getEvent();
 }
 
-void kdraw_screen_region(const u32 *frame_buffer) {
+void kdraw_screen_region(const u32* frame_buffer)
+{
     VideoGraphicsArray::get().drawRegion(frame_buffer);
 }
 
-void kclear_terminal() {
+void kclear_terminal()
+{
     Terminal::clear();
 }
 
 #include "../../ArtOS_lib/kernel.h"
 
-void syscall_handler(cpu_registers_t *r) {
+void syscall_handler(cpu_registers_t* r)
+{
     u64 large_res;
-    switch (static_cast<SYSCALL_t>(r->eax)) {
-        case SYSCALL_t::WRITE: {
-            // TODO: this is no where near this simple for hardware files. Interrupts are needed for IO so the task must be slept and the interrupt handled correctly.
-            // TODO: mapping user space data!
-            // TODO: mapping a single page will be a problem if the buffer is close to the end of the page
-
-            r->eax = art_write(static_cast<int>(r->ebx), reinterpret_cast<char *>(r->ecx), r->edx);
+    switch (static_cast<SYSCALL_t>(r->eax))
+    {
+    case SYSCALL_t::WRITE:
+        {
+            r->eax = art_write(static_cast<int>(r->ebx), reinterpret_cast<char*>(r->ecx), r->edx);
             break;
         }
-        case SYSCALL_t::READ: {
-            {
-                // TODO: this should actually just always sleep the device and then this should be in the scheduler cleanup
-                if (art_dev_busy(r->ebx))
-                {
-                    Scheduler::mark_process_as_waiting(r, Process::DEV_BUSY, r->ebx);
-                }
-#if ASYNC_READ
-                switch (const int res = art_async_read(static_cast<int>(r->ebx), reinterpret_cast<char *>(r->ecx),
-                                                       r->edx)) {
-                    case -1:
-#if ENABLE_SERIAL_LOGGING and LOG_SYSCALL
-                        get_serial().log("Async not enabled, using synchronous read");
-#endif
-                        r->eax = art_read(static_cast<int>(r->ebx), reinterpret_cast<char *>(r->ecx), r->edx);
-                        break;
-                    case 0:
-                        // todo: sleep process and mark as waiting for files
-#if ENABLE_SERIAL_LOGGING and LOG_SYSCALL
-                        get_serial().log("starting async read by pausing process");
-#endif
-                        Scheduler::mark_process_as_waiting(r, Process::FILE_READING, r->ebx);
-                        break;
-                    default:
-#if ENABLE_SERIAL_LOGGING and LOG_SYSCALL
-                        get_serial().log(res, " bytes of data already in buffer, returning directly");
-#endif
-                        r->eax = res;
-                        break;
-                }
-                break;
-#else
-#if ENABLE_SERIAL_LOGGING and LOG_SYSCALL
-                get_serial().log("Async not enabled, using synchronous read");
-#endif
-                r->eax = art_read(static_cast<int>(r->ebx), reinterpret_cast<char *>(r->ecx), r->edx);
-                break;
-#endif
-            }
-        }
-        case SYSCALL_t::OPEN: {
-            // TODO: this is no where near this simple for hardware files. Interrupts are needed for IO so the task must be slept and the interrupt handled correctly.
-            // TODO: mapping user space data!
-            r->eax = art_open(reinterpret_cast<char *>(r->ebx), r->ecx);
+    case SYSCALL_t::READ:
+        {
+            Scheduler::append_read(r);
             break;
         }
-        case SYSCALL_t::SEEK: {
+    case SYSCALL_t::OPEN:
+        {
+            // TODO: this is no where near this simple for hardware files. Interrupts are needed for IO so the task must be slept and the interrupt handled correctly.
+            // TODO: mapping user space data!
+            r->eax = art_open(reinterpret_cast<char*>(r->ebx), r->ecx);
+            break;
+        }
+    case SYSCALL_t::SEEK:
+        {
             large_res = art_seek(r->ebx, r->ecx << 32 | r->edx, r->esi);
             r->eax = large_res >> 32;
             r->ebx = large_res & 0xFFFFFFFF;
         }
         break;
-        case SYSCALL_t::CLOSE: {
+    case SYSCALL_t::CLOSE:
+        {
             art_close(r->ebx);
             break;
         }
-        case SYSCALL_t::EXIT: {
+    case SYSCALL_t::EXIT:
+        {
             Scheduler::exit(r);
             break;
         }
-        case SYSCALL_t::SLEEP_MS: {
+    case SYSCALL_t::SLEEP_MS:
+        {
             ksleep_ms(r);
             break;
         }
-        case SYSCALL_t::GET_TICK_MS: {
+    case SYSCALL_t::GET_TICK_MS:
+        {
             r->eax = kget_tick_ms() & 0xffffffff;
             break;
         }
-        case SYSCALL_t::PROBE_EVENTS: {
+    case SYSCALL_t::PROBE_EVENTS:
+        {
             r->eax = kprobe_pending_events();
             break;
         }
-        case SYSCALL_t::GET_EVENT: {
+    case SYSCALL_t::GET_EVENT:
+        {
             auto [type, data] = kget_next_event();
             r->eax = type;
             r->ebx = data.lower_data;
             r->ecx = data.upper_data;
             break;
         }
-        case SYSCALL_t::DRAW_REGION: {
-            kdraw_screen_region(reinterpret_cast<u32 *>(r->ebx));
+    case SYSCALL_t::DRAW_REGION:
+        {
+            kdraw_screen_region(reinterpret_cast<u32*>(r->ebx));
             break;
         }
-        case SYSCALL_t::CLEAR_TERM: {
+    case SYSCALL_t::CLEAR_TERM:
+        {
             kclear_terminal();
             break;
         }
-        case SYSCALL_t::GET_TIME: {
-            r->eax = kget_time(reinterpret_cast<tm *>(r->ebx));
+    case SYSCALL_t::GET_TIME:
+        {
+            r->eax = kget_time(reinterpret_cast<tm*>(r->ebx));
             break;
         }
-        case SYSCALL_t::GET_EPOCH: {
+    case SYSCALL_t::GET_EPOCH:
+        {
             r->eax = kget_epoch_time();
             break;
         }
-        case SYSCALL_t::MMAP: {
+    case SYSCALL_t::MMAP:
+        {
             // *reinterpret_cast<u32*>(r->ebp) + 7)
             r->eax = reinterpret_cast<u32>(user_mmap(r->ebx, r->ecx, r->edx, r->esi, r->edi, 0));
             break;
         }
-        case SYSCALL_t::MUNMAP: {
-            r->eax = user_munmap(reinterpret_cast<void *>(r->ebx), r->ecx);
+    case SYSCALL_t::MUNMAP:
+        {
+            r->eax = user_munmap(reinterpret_cast<void*>(r->ebx), r->ecx);
             break;
         }
-        case SYSCALL_t::GET_CURRENT_CLOCK: {
+    case SYSCALL_t::GET_CURRENT_CLOCK:
+        {
             large_res = kget_current_clock();
             r->eax = static_cast<u32>(large_res);
             r->ebx = static_cast<u32>(large_res >> 32);
             break;
         }
-        case SYSCALL_t::EXECF: {
+    case SYSCALL_t::EXECF:
+        {
             r->eax = art_exec(r->ebx);
             break;
         }
-        case SYSCALL_t::YIELD: {
+    case SYSCALL_t::YIELD:
+        {
             Scheduler::schedule(r);
             break;
         }
-        default: {
+    default:
+        {
             LOG("Unhandled Syscall: ", static_cast<u32>(r->eax));
             r->eax = -1;
             break;

--- a/pdclib/functions/stdio/fread.c
+++ b/pdclib/functions/stdio/fread.c
@@ -1,3 +1,19 @@
+// ArtOS - hobby operating system by Artie Poole
+// Copyright (C) 2025 Stuart Forbes Poole <artiepoole>
+//
+//     This program is free software: you can redistribute it and/or modify
+//     it under the terms of the GNU General Public License as published by
+//     the Free Software Foundation, either version 3 of the License, or
+//     (at your option) any later version.
+//
+//     This program is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//     GNU General Public License for more details.
+//
+//     You should have received a copy of the GNU General Public License
+//     along with this program.  If not, see <https://www.gnu.org/licenses/>
+
 /* fread( void *, size_t, size_t, struct * )
 
    This file is part of the Public Domain C Library (PDCLib).
@@ -21,40 +37,39 @@ size_t fread(void* _PDCLIB_restrict ptr, size_t size, size_t nmemb, struct _PDCL
 {
     // TODO: proper implementation of this stream handling stuff,
 
-    //
-    // char * dest = ( char * )ptr;
-    // size_t nmemb_i = 0;
-    //
-    // _PDCLIB_LOCK( stream->mtx );
-    //
-    // if ( _PDCLIB_prepread( stream ) != EOF )
-    // {
-    //     for ( nmemb_i = 0; nmemb_i < nmemb; ++nmemb_i )
-    //     {
-    //         size_t size_i;
-    //
-    //         /* TODO: For better performance, move from stream buffer
-    //            to destination block-wise, not byte-wise.
-    //         */
-    //         for ( size_i = 0; size_i < size; ++size_i )
-    //         {
-    //             if ( _PDCLIB_CHECKBUFFER( stream ) == EOF )
-    //             {
-    //                 /* Could not read requested data */
-    //                 _PDCLIB_UNLOCK( stream->mtx );
-    //                 return nmemb_i;
-    //             }
-    //
-    //             dest[ nmemb_i * size + size_i ] = _PDCLIB_GETC( stream );
-    //         }
-    //     }
-    //
-    // }
-    //
-    // _PDCLIB_UNLOCK( stream->mtx );
-    //
-    // return nmemb_i;
-    return read(stream->handle, ptr, nmemb * size);
+
+    char* dest = (char*)ptr;
+    size_t nmemb_i = 0;
+
+    _PDCLIB_LOCK(stream->mtx);
+
+    if (_PDCLIB_prepread(stream) != EOF)
+    {
+        for (nmemb_i = 0; nmemb_i < nmemb; ++nmemb_i)
+        {
+            size_t size_i;
+
+            /* TODO: For better performance, move from stream buffer
+               to destination block-wise, not byte-wise.
+            */
+            for (size_i = 0; size_i < size; ++size_i)
+            {
+                if (_PDCLIB_CHECKBUFFER(stream) == EOF)
+                {
+                    /* Could not read requested data */
+                    _PDCLIB_UNLOCK(stream->mtx);
+                    return nmemb_i;
+                }
+
+                dest[nmemb_i * size + size_i] = _PDCLIB_GETC(stream);
+            }
+        }
+    }
+
+    _PDCLIB_UNLOCK(stream->mtx);
+
+    return nmemb_i;
+    // return read(stream->handle, ptr, nmemb * size);
 }
 
 #endif

--- a/pdclib/functions/stdio/fread.c
+++ b/pdclib/functions/stdio/fread.c
@@ -22,39 +22,39 @@ size_t fread(void* _PDCLIB_restrict ptr, size_t size, size_t nmemb, struct _PDCL
     // TODO: proper implementation of this stream handling stuff,
 
     //
-    char * dest = ( char * )ptr;
-    size_t nmemb_i = 0;
-
-    _PDCLIB_LOCK( stream->mtx );
-
-    if ( _PDCLIB_prepread( stream ) != EOF )
-    {
-        for ( nmemb_i = 0; nmemb_i < nmemb; ++nmemb_i )
-        {
-            size_t size_i;
-
-            /* TODO: For better performance, move from stream buffer
-               to destination block-wise, not byte-wise.
-            */
-            for ( size_i = 0; size_i < size; ++size_i )
-            {
-                if ( _PDCLIB_CHECKBUFFER( stream ) == EOF )
-                {
-                    /* Could not read requested data */
-                    _PDCLIB_UNLOCK( stream->mtx );
-                    return nmemb_i;
-                }
-
-                dest[ nmemb_i * size + size_i ] = _PDCLIB_GETC( stream );
-            }
-        }
-
-    }
-
-    _PDCLIB_UNLOCK( stream->mtx );
-
-    return nmemb_i;
-    // return read(stream->handle, ptr, nmemb * size);
+    // char * dest = ( char * )ptr;
+    // size_t nmemb_i = 0;
+    //
+    // _PDCLIB_LOCK( stream->mtx );
+    //
+    // if ( _PDCLIB_prepread( stream ) != EOF )
+    // {
+    //     for ( nmemb_i = 0; nmemb_i < nmemb; ++nmemb_i )
+    //     {
+    //         size_t size_i;
+    //
+    //         /* TODO: For better performance, move from stream buffer
+    //            to destination block-wise, not byte-wise.
+    //         */
+    //         for ( size_i = 0; size_i < size; ++size_i )
+    //         {
+    //             if ( _PDCLIB_CHECKBUFFER( stream ) == EOF )
+    //             {
+    //                 /* Could not read requested data */
+    //                 _PDCLIB_UNLOCK( stream->mtx );
+    //                 return nmemb_i;
+    //             }
+    //
+    //             dest[ nmemb_i * size + size_i ] = _PDCLIB_GETC( stream );
+    //         }
+    //     }
+    //
+    // }
+    //
+    // _PDCLIB_UNLOCK( stream->mtx );
+    //
+    // return nmemb_i;
+    return read(stream->handle, ptr, nmemb * size);
 }
 
 #endif


### PR DESCRIPTION
The async_read is only used via syscalls because it doesn't make sense to call async read during kernel init.

ASYNC_READ compile option added to cmake because it's slower than sync read (but better in multithreaded situations of course!)

Added context_switch_period_us setting to compile times: 1ms for debug and 100us for release.